### PR TITLE
Push package com.uz.wcf.bot3.lexicon to version 5.5.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags: ['*']
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Create package
+        run: |
+          rm -rf *.tar.gz
+          npx --yes wspackager
+
+      - name: Check file existence
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          #files: "${{ github.event.repository.name }}_*.tar.gz"
+          files: "de.softcreatr*.tar.gz"
+
+      - name: On Build Failure
+        if: steps.check_files.outputs.files_exists == 'false'
+        run: |
+          echo "Packaging FAILED" && exit 1
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') && steps.check_files.outputs.files_exists == 'true'
+        with:
+          #files: "${{ github.event.repository.name }}_*.tar.gz"
+          files: "de.softcreatr*.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,23 +12,22 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2.4.2
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3.5.0
         with:
           node-version: 16
 
       - name: Create package
         run: |
           rm -rf *.tar.gz
-          npx --yes wspackager
+          npx --yes wspackager@latest
 
       - name: Check file existence
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v1.1.0
         with:
-          #files: "${{ github.event.repository.name }}_*.tar.gz"
-          files: "de.softcreatr*.tar.gz"
+          files: "*.tar.gz"
 
       - name: On Build Failure
         if: steps.check_files.outputs.files_exists == 'false'
@@ -36,8 +35,7 @@ jobs:
           echo "Packaging FAILED" && exit 1
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.14
         if: startsWith(github.ref, 'refs/tags/') && steps.check_files.outputs.files_exists == 'true'
         with:
-          #files: "${{ github.event.repository.name }}_*.tar.gz"
-          files: "de.softcreatr*.tar.gz"
+          files: "*.tar.gz"

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,132 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+	->exclude('*/vendor/*')
+	->in(__DIR__)
+	->notPath('lib/system/api');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR1' => true,
+        '@PSR2' => true,
+
+        'array_push' => true,
+        'backtick_to_shell_exec' => true,
+        'no_alias_language_construct_call' => true,
+        'no_mixed_echo_print' => true,
+        'pow_to_exponentiation' => true,
+        'random_api_migration' => true,
+
+        'array_syntax' => ['syntax' => 'short'],
+        'no_multiline_whitespace_around_double_arrow' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'normalize_index_brace' => true,
+        'whitespace_after_comma_in_array' => true,
+
+        'non_printable_character' => ['use_escape_sequences_in_strings' => true],
+
+        'lowercase_static_reference' => true,
+        'magic_constant_casing' => true,
+        'magic_method_casing' => true,
+        'native_function_casing' => true,
+        'native_function_type_declaration_casing' => true,
+
+        'cast_spaces' => ['space' => 'none'],
+        'lowercase_cast' => true,
+        'no_unset_cast' => true,
+        'short_scalar_cast' => true,
+
+        'class_attributes_separation' => true,
+        'no_blank_lines_after_class_opening' => true,
+        'no_null_property_initialization' => true,
+        'self_accessor' => true,
+        'single_class_element_per_statement' => true,
+        'single_trait_insert_per_statement' => true,
+
+        'no_empty_comment' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+
+        'native_constant_invocation' => ['strict' => false],
+
+        'no_alternative_syntax' => true,
+        'no_trailing_comma_in_list_call' => true,
+        'no_unneeded_control_parentheses' => ['statements' => ['break', 'clone', 'continue', 'echo_print', 'return', 'switch_case', 'yield', 'yield_from']],
+        'no_unneeded_curly_braces' => ['namespaces' => true],
+        'switch_continue_to_break' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+
+        'function_typehint_space' => true,
+        'lambda_not_used_import' => true,
+        'native_function_invocation' => ['include' => ['@all']],
+        'no_unreachable_default_argument_value' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
+        'return_type_declaration' => true,
+        'static_lambda' => true,
+
+        'fully_qualified_strict_types' => true,
+        'no_leading_import_slash' => true,
+        'no_unused_imports' => true,
+        //'ordered_imports' => true,
+
+        'declare_equal_normalize' => true,
+        'dir_constant' => true,
+        'explicit_indirect_variable' => true,
+        'function_to_constant' => true,
+        'is_null' => true,
+        'no_unset_on_property' => true,
+
+        'list_syntax' => ['syntax' => 'short'],
+
+        'clean_namespace' => true,
+        'no_leading_namespace_whitespace' => true,
+        'single_blank_line_before_namespace' => true,
+
+        'no_homoglyph_names' => true,
+
+        'binary_operator_spaces' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'increment_style' => ['style' => 'post'],
+        'logical_operators' => true,
+        'object_operator_without_whitespace' => true,
+        'operator_linebreak' => true,
+        'standardize_increment' => true,
+        'standardize_not_equals' => true,
+        'ternary_operator_spaces' => true,
+        'ternary_to_elvis_operator' => true,
+        'ternary_to_null_coalescing' => true,
+        'unary_operator_spaces' => true,
+
+        'no_useless_return' => true,
+        'return_assignment' => true,
+
+        'multiline_whitespace_before_semicolons' => true,
+        'no_empty_statement' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'space_after_semicolon' => ['remove_in_empty_for_expressions' => true],
+
+        'escape_implicit_backslashes' => true,
+        'explicit_string_variable' => true,
+        'heredoc_to_nowdoc' => true,
+        'no_binary_string' => true,
+        'simple_to_complex_string_variable' => true,
+
+        'array_indentation' => true,
+        'blank_line_before_statement' => ['statements' => ['return', 'exit']],
+        'compact_nullable_typehint' => true,
+        'method_chaining_indentation' => true,
+        'no_extra_blank_lines' => ['tokens' => ['case', 'continue', 'curly_brace_block', 'default', 'extra', 'parenthesis_brace_block', 'square_brace_block', 'switch', 'throw', 'use']],
+        'no_spaces_around_offset' => true,
+
+        // SoftCreatR style
+        'blank_line_between_import_groups' => true,
+        'global_namespace_import' => [
+            'import_classes' => true,
+            'import_constants' => true,
+            'import_functions' => false,
+        ],
+        'ordered_imports' => [
+            'imports_order' => ['class', 'function', 'const'],
+        ],
+    ])
+    ->setFinder($finder);

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,458 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS

--- a/acptemplates/__uzbotAddTypeLexicon.tpl
+++ b/acptemplates/__uzbotAddTypeLexicon.tpl
@@ -1,104 +1,104 @@
 <script data-relocate="true">
-	require(['WoltLabSuite/Core/Ui/User/Search/Input'], function(UiUserSearchInput) {
-		new UiUserSearchInput(elBySel('input[name="lexiconModificationExecuter"]'));
-	});
+    require(['WoltLabSuite/Core/Ui/User/Search/Input'], function(UiUserSearchInput) {
+        new UiUserSearchInput(elBySel('input[name="lexiconModificationExecuter"]'));
+    });
 </script>
 
 <div class="section lexicon_new">
-	<header class="sectionHeader">
-		<h2 class="sectionTitle">{lang}wcf.acp.uzbot.setting{/lang}</h2>
-	</header>
+    <header class="sectionHeader">
+        <h2 class="sectionTitle">{lang}wcf.acp.uzbot.setting{/lang}</h2>
+    </header>
 </div>
 
 <div class="section lexicon_change">
-	<header class="sectionHeader">
-		<h2 class="sectionTitle">{lang}wcf.acp.uzbot.setting{/lang}</h2>
-	</header>
-	
-	<dl{if $errorField == 'lexiconChangeAction'} class="formError"{/if}>
-		<dt>{lang}wcf.acp.uzbot.lexicon.entryChange.action{/lang}</dt>
-		<dd>
-			<label><input type="checkbox" name="lexiconChangeUpdate" value="1"{if $lexiconChangeUpdate} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryChange.update{/lang}</label>
-			<label><input type="checkbox" name="lexiconChangeDelete" value="1"{if $lexiconChangeDelete} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryChange.delete{/lang}</label>
-			
-			{if $errorField == 'lexiconChangeAction'}
-				<small class="innerError">
-					{lang}wcf.acp.uzbot.lexicon.entryChange.action.error.notConfigured{/lang}
-				</small>
-			{/if}
-		</dd>
-	</dl>
+    <header class="sectionHeader">
+        <h2 class="sectionTitle">{lang}wcf.acp.uzbot.setting{/lang}</h2>
+    </header>
+
+    <dl{if $errorField == 'lexiconChangeAction'} class="formError"{/if}>
+        <dt>{lang}wcf.acp.uzbot.lexicon.entryChange.action{/lang}</dt>
+        <dd>
+            <label><input type="checkbox" name="lexiconChangeUpdate" value="1"{if $lexiconChangeUpdate} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryChange.update{/lang}</label>
+            <label><input type="checkbox" name="lexiconChangeDelete" value="1"{if $lexiconChangeDelete} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryChange.delete{/lang}</label>
+
+            {if $errorField == 'lexiconChangeAction'}
+                <small class="innerError">
+                    {lang}wcf.acp.uzbot.lexicon.entryChange.action.error.notConfigured{/lang}
+                </small>
+            {/if}
+        </dd>
+    </dl>
 </div>
 
 <div class="section lexicon_modification">
-	<header class="sectionHeader">
-		<h2 class="sectionTitle">{lang}wcf.acp.uzbot.lexicon.entryModification.setting{/lang}</h2>
-	</header>
-	
-	<dl{if $errorField == 'lexiconModificationExecuter'} class="formError"{/if}>
-		<dt><label for="lexiconModificationExecuter">{lang}wcf.acp.uzbot.lexicon.entryModification.executer{/lang}</label></dt>
-		<dd>
-			<input type="text" id="lexiconModificationExecuter" name="lexiconModificationExecuter" value="{$lexiconModificationExecuter}" class="medium" maxlength="255">
-			<small>{lang}wcf.acp.uzbot.lexicon.entryModification.executer.description{/lang}</small>
-			
-			{if $errorField == 'lexiconModificationExecuter'}
-				<small class="innerError">
-					{if $errorField == 'lexiconModificationExecuter'}
-						{lang}wcf.acp.uzbot.lexicon.entryModification.executer.error.{@$errorType}{/lang}
-					{/if}
-				</small>
-			{/if}
-		</dd>
-	</dl>
-	
-	<dl{if $errorField == 'lexiconModificationAction'} class="formError"{/if}>
-		<dt>{lang}wcf.acp.uzbot.lexicon.entryModification.action{/lang}</dt>
-		<dd>
-			<label><input type="checkbox" name="lexiconModificationEnable" value="1"{if $lexiconModificationEnable} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.enable{/lang}</label>
-			<label><input type="checkbox" name="lexiconModificationDisable" value="1"{if $lexiconModificationDisable} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.disable{/lang}</label>
-			<label><input type="checkbox" name="lexiconModificationComplete" value="1"{if $lexiconModificationComplete} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.complete{/lang}</label>
-			<label><input type="checkbox" name="lexiconModificationUncomplete" value="1"{if $lexiconModificationUncomplete} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.uncomplete{/lang}</label>
-			{if $labelGroups|count && $availableLabels|count}
-				<label><input type="checkbox" name="lexiconModificationSetLabel" value="1"{if $lexiconModificationSetLabel} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.setLabels{/lang}</label>
-			{/if}
-			
-			{if $errorField == 'lexiconModificationAction'}
-				<small class="innerError">
-					{lang}wcf.acp.uzbot.lexicon.entryModification.action.error.notConfigured{/lang}
-				</small>
-			{/if}
-		</dd>
-	</dl>
+    <header class="sectionHeader">
+        <h2 class="sectionTitle">{lang}wcf.acp.uzbot.lexicon.entryModification.setting{/lang}</h2>
+    </header>
+
+    <dl{if $errorField == 'lexiconModificationExecuter'} class="formError"{/if}>
+        <dt><label for="lexiconModificationExecuter">{lang}wcf.acp.uzbot.lexicon.entryModification.executer{/lang}</label></dt>
+        <dd>
+            <input type="text" id="lexiconModificationExecuter" name="lexiconModificationExecuter" value="{$lexiconModificationExecuter}" class="medium" maxlength="255">
+            <small>{lang}wcf.acp.uzbot.lexicon.entryModification.executer.description{/lang}</small>
+
+            {if $errorField == 'lexiconModificationExecuter'}
+                <small class="innerError">
+                    {if $errorField == 'lexiconModificationExecuter'}
+                        {lang}wcf.acp.uzbot.lexicon.entryModification.executer.error.{@$errorType}{/lang}
+                    {/if}
+                </small>
+            {/if}
+        </dd>
+    </dl>
+
+    <dl{if $errorField == 'lexiconModificationAction'} class="formError"{/if}>
+        <dt>{lang}wcf.acp.uzbot.lexicon.entryModification.action{/lang}</dt>
+        <dd>
+            <label><input type="checkbox" name="lexiconModificationEnable" value="1"{if $lexiconModificationEnable} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.enable{/lang}</label>
+            <label><input type="checkbox" name="lexiconModificationDisable" value="1"{if $lexiconModificationDisable} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.disable{/lang}</label>
+            <label><input type="checkbox" name="lexiconModificationComplete" value="1"{if $lexiconModificationComplete} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.complete{/lang}</label>
+            <label><input type="checkbox" name="lexiconModificationUncomplete" value="1"{if $lexiconModificationUncomplete} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.uncomplete{/lang}</label>
+            {if $labelGroups|count && $availableLabels|count}
+                <label><input type="checkbox" name="lexiconModificationSetLabel" value="1"{if $lexiconModificationSetLabel} checked{/if}> {lang}wcf.acp.uzbot.lexicon.entryModification.setLabels{/lang}</label>
+            {/if}
+
+            {if $errorField == 'lexiconModificationAction'}
+                <small class="innerError">
+                    {lang}wcf.acp.uzbot.lexicon.entryModification.action.error.notConfigured{/lang}
+                </small>
+            {/if}
+        </dd>
+    </dl>
 </div>
 
 <div class="section lexiconConditionSettings">
-	<header class="sectionHeader">
-		<h2 class="sectionTitle">{lang}wcf.acp.uzbot.lexicon.entry.condition{/lang}</h2>
-		<p class="sectionDescription">{lang}wcf.acp.uzbot.lexicon.entry.condition.description{/lang}</p>
-	</header>
-	
-	<section>
-		{foreach from=$lexiconConditions key='conditionGroup' item='conditionObjectTypes'}
-			<div id="lexicon_{$conditionGroup}">
-				<section class="section">
-					{foreach from=$conditionObjectTypes item='condition'}
-						{@$condition->getProcessor()->getHtml()}
-					{/foreach}
-				</section>
-			</div>
-		{/foreach}
-		
-		<dl>
-			<dt><label for="lexiconModificationCategoryID">{lang}wcf.acp.uzbot.lexicon.entryModification.category{/lang}</label></dt>
-			<dd>
-				<select name="lexiconModificationCategoryID" id="lexiconModificationCategoryID">
-					<option value="0">{lang}wcf.global.noSelection{/lang}</option>
-					
-					{foreach from=$lexiconCategoryNodeList item=category}
-						<option value="{@$category->categoryID}"{if $category->categoryID == $lexiconModificationCategoryID} selected{/if}>{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
-					{/foreach}
-				</select>
-			</dd>
-		</dl>
-	</section>
+    <header class="sectionHeader">
+        <h2 class="sectionTitle">{lang}wcf.acp.uzbot.lexicon.entry.condition{/lang}</h2>
+        <p class="sectionDescription">{lang}wcf.acp.uzbot.lexicon.entry.condition.description{/lang}</p>
+    </header>
+
+    <section>
+        {foreach from=$lexiconConditions key='conditionGroup' item='conditionObjectTypes'}
+            <div id="lexicon_{$conditionGroup}">
+                <section class="section">
+                    {foreach from=$conditionObjectTypes item='condition'}
+                        {@$condition->getProcessor()->getHtml()}
+                    {/foreach}
+                </section>
+            </div>
+        {/foreach}
+
+        <dl>
+            <dt><label for="lexiconModificationCategoryID">{lang}wcf.acp.uzbot.lexicon.entryModification.category{/lang}</label></dt>
+            <dd>
+                <select name="lexiconModificationCategoryID" id="lexiconModificationCategoryID">
+                    <option value="0">{lang}wcf.global.noSelection{/lang}</option>
+
+                    {foreach from=$lexiconCategoryNodeList item=category}
+                        <option value="{@$category->categoryID}"{if $category->categoryID == $lexiconModificationCategoryID} selected{/if}>{if $category->getDepth() > 1}{@"&nbsp;&nbsp;&nbsp;&nbsp;"|str_repeat:($category->getDepth() - 1)}{/if}{$category->getTitle()}</option>
+                    {/foreach}
+                </select>
+            </dd>
+        </dl>
+    </section>
 </div>

--- a/acptemplates/__uzbotAddTypeLexiconJS.tpl
+++ b/acptemplates/__uzbotAddTypeLexiconJS.tpl
@@ -2,16 +2,16 @@ $('.lexicon_new, .lexicon_modification, .lexicon_change').hide();
 $('.lexiconConditionSettings').hide();
 
 if (value == 200) {
-	$('.lexicon_change, .uzbotUserConditions').show();
-	$('#receiverAffected').show();
+    $('.lexicon_change, .uzbotUserConditions').show();
+    $('#receiverAffected').show();
 }
 
 if (value == 201) {
-	$('.lexicon_modification, .lexiconConditionSettings').show();
-	$('#receiverAffected, #actionLabelContainer, #conditionLabelContainer').show();
+    $('.lexicon_modification, .lexiconConditionSettings').show();
+    $('#receiverAffected, #actionLabelContainer, #conditionLabelContainer').show();
 }
 
 if (value == 202) {
-	$('.lexicon_new, .uzbotUserConditions').show();
-	$('#receiverAffected').show();
+    $('.lexicon_new, .uzbotUserConditions').show();
+    $('#receiverAffected').show();
 }

--- a/cronjob.xml
+++ b/cronjob.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/cronjob.xsd">
-	<import>
-		<cronjob name="uzbotLexiconModify">
-			<classname>lexicon\system\cronjob\UzbotLexiconModificationCronjob</classname>
-			<description><![CDATA[Community Bot - Lexicon Modification]]></description>
-			<description language="de"><![CDATA[Community Bot - Lexikon Bearbeitung]]></description>
-			<startminute>*/30</startminute>
-			<starthour>*</starthour>
-			<startdom>*</startdom>
-			<startmonth>*</startmonth>
-			<startdow>*</startdow>
-			<active>1</active>
-			<canbeedited>1</canbeedited>
-			<canbedisabled>1</canbedisabled>
-		</cronjob>
-	</import>
+    <import>
+        <cronjob name="uzbotLexiconModify">
+            <classname>lexicon\system\cronjob\UzbotLexiconModificationCronjob</classname>
+            <description><![CDATA[Community Bot - Lexicon Modification]]></description>
+            <description language="de"><![CDATA[Community Bot - Lexikon Bearbeitung]]></description>
+            <startminute>*/30</startminute>
+            <starthour>*</starthour>
+            <startdom>*</startdom>
+            <startmonth>*</startmonth>
+            <startdow>*</startdow>
+            <active>1</active>
+            <canbeedited>1</canbeedited>
+            <canbedisabled>1</canbedisabled>
+        </cronjob>
+    </import>
 </data>

--- a/eventListener.xml
+++ b/eventListener.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/eventListener.xsd">
-	<import>
-		<eventlistener name="uzbotAddLexiconInherited">
-			<eventclassname>wcf\acp\form\UzbotAddForm</eventclassname>
-			<eventname>assignVariables,readFormParameters,save,validate,saved</eventname>
-			<listenerclassname>lexicon\system\event\listener\UzbotAddFormLexiconListener</listenerclassname>
-			<inherit>1</inherit>
-			<environment>admin</environment>
-		</eventlistener>
-		
-		<eventlistener name="uzbotEditLexiconReadData">
-			<eventclassname>wcf\acp\form\UzbotEditForm</eventclassname>
-			<eventname>readData</eventname>
-			<listenerclassname>lexicon\system\event\listener\UzbotAddFormLexiconListener</listenerclassname>
-			<environment>admin</environment>
-		</eventlistener>
-		
-		<eventlistener name="uzbotLexiconEntryAction">
-			<eventclassname>lexicon\data\entry\EntryAction</eventclassname>
-			<eventname>finalizeAction</eventname>
-			<listenerclassname>lexicon\system\event\listener\UzbotLexiconActionListener</listenerclassname>
-			<environment>user</environment>
-		</eventlistener>
-		
-		<eventlistener name="uzbotLexiconDeleteBotAction">
-			<eventclassname>wcf\data\uzbot\UzbotAction</eventclassname>
-			<eventname>finalizeAction</eventname>
-			<listenerclassname>lexicon\system\event\listener\UzbotLexiconDeleteBotListener</listenerclassname>
-			<environment>admin</environment>
-		</eventlistener>
-	</import>
+    <import>
+        <eventlistener name="uzbotAddLexiconInherited">
+            <eventclassname>wcf\acp\form\UzbotAddForm</eventclassname>
+            <eventname>assignVariables,readFormParameters,save,validate,saved</eventname>
+            <listenerclassname>lexicon\system\event\listener\UzbotAddFormLexiconListener</listenerclassname>
+            <inherit>1</inherit>
+            <environment>admin</environment>
+        </eventlistener>
+
+        <eventlistener name="uzbotEditLexiconReadData">
+            <eventclassname>wcf\acp\form\UzbotEditForm</eventclassname>
+            <eventname>readData</eventname>
+            <listenerclassname>lexicon\system\event\listener\UzbotAddFormLexiconListener</listenerclassname>
+            <environment>admin</environment>
+        </eventlistener>
+
+        <eventlistener name="uzbotLexiconEntryAction">
+            <eventclassname>lexicon\data\entry\EntryAction</eventclassname>
+            <eventname>finalizeAction</eventname>
+            <listenerclassname>lexicon\system\event\listener\UzbotLexiconActionListener</listenerclassname>
+            <environment>user</environment>
+        </eventlistener>
+
+        <eventlistener name="uzbotLexiconDeleteBotAction">
+            <eventclassname>wcf\data\uzbot\UzbotAction</eventclassname>
+            <eventname>finalizeAction</eventname>
+            <listenerclassname>lexicon\system\event\listener\UzbotLexiconDeleteBotListener</listenerclassname>
+            <environment>admin</environment>
+        </eventlistener>
+    </import>
 </data>

--- a/files/lib/system/condition/uzbot/UzbotLexiconConditionHandler.class.php
+++ b/files/lib/system/condition/uzbot/UzbotLexiconConditionHandler.class.php
@@ -1,42 +1,65 @@
 <?php
+
+/*
+ * Copyright by Udo Zaydowicz.
+ * Modified by SoftCreatR.dev.
+ *
+ * License: http://opensource.org/licenses/lgpl-license.php
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 namespace lexicon\system\condition\uzbot;
+
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\system\SingletonFactory;
 
 /**
  * Handles bot conditions.
- *
- * @author		2019-2022 Zaydowicz
- * @license		GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package		com.uz.wcf.bot3.lexicon
  */
-class UzbotLexiconConditionHandler extends SingletonFactory {
-	/**
-	 * list of grouped user group / inactive assignment condition object types
-	 */
-	protected $groupedObjectTypes = [];
+class UzbotLexiconConditionHandler extends SingletonFactory
+{
+    /**
+     * list of grouped user group / inactive assignment condition object types
+     */
+    protected $groupedObjectTypes = [];
 
-	/**
-	 * Returns the list of grouped user group / inactive assignment condition object types.
-	 */
-	public function getGroupedObjectTypes() {
-		return $this->groupedObjectTypes;
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected function init() {
-		$objectTypes = ObjectTypeCache::getInstance()->getObjectTypes('com.uz.wcf.bot.condition.lexicon');
-		
-		foreach ($objectTypes as $objectType) {
-			if (!$objectType->conditiongroup) continue;
-			
-			if (!isset($this->groupedObjectTypes[$objectType->conditiongroup])) {
-				$this->groupedObjectTypes[$objectType->conditiongroup] = [];
-			}
-			
-			$this->groupedObjectTypes[$objectType->conditiongroup][$objectType->objectTypeID] = $objectType;
-		}
-	}
+    /**
+     * Returns the list of grouped user group / inactive assignment condition object types.
+     */
+    public function getGroupedObjectTypes()
+    {
+        return $this->groupedObjectTypes;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function init()
+    {
+        $objectTypes = ObjectTypeCache::getInstance()->getObjectTypes('com.uz.wcf.bot.condition.lexicon');
+
+        foreach ($objectTypes as $objectType) {
+            if (!$objectType->conditiongroup) {
+                continue;
+            }
+
+            if (!isset($this->groupedObjectTypes[$objectType->conditiongroup])) {
+                $this->groupedObjectTypes[$objectType->conditiongroup] = [];
+            }
+
+            $this->groupedObjectTypes[$objectType->conditiongroup][$objectType->objectTypeID] = $objectType;
+        }
+    }
 }

--- a/files/lib/system/condition/uzbot/UzbotLexiconCreateDateIntervalCondition.class.php
+++ b/files/lib/system/condition/uzbot/UzbotLexiconCreateDateIntervalCondition.class.php
@@ -1,5 +1,28 @@
 <?php
+
+/*
+ * Copyright by Udo Zaydowicz.
+ * Modified by SoftCreatR.dev.
+ *
+ * License: http://opensource.org/licenses/lgpl-license.php
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 namespace lexicon\system\condition\uzbot;
+
+use InvalidArgumentException;
 use lexicon\data\entry\Entry;
 use lexicon\data\entry\EntryList;
 use wcf\data\condition\Condition;
@@ -11,85 +34,84 @@ use wcf\system\WCF;
 
 /**
  * Condition implementation for an integer to day property of an entry.
- * 
- * @author		2019-2022 Zaydowicz
- * @license		GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package		com.uz.wcf.bot3.lexicon
  */
-class UzbotLexiconCreateDateIntervalCondition extends AbstractIntegerCondition implements IObjectListCondition {
-	/**
-	 * @inheritDoc
-	 */
-	protected $label = 'wcf.acp.uzbot.lexicon.condition.createTime';
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected $minValue = 0;
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function addObjectListCondition(DatabaseObjectList $objectList, array $conditionData) {
-		if (!($objectList instanceof EntryList)) {
-			throw new \InvalidArgumentException("Object list is no instance of '".EntryList::class."', instance of '".get_class($objectList)."' given.");
-		}
-		
-		if (isset($conditionData['greaterThan'])) {
-			$objectList->getConditionBuilder()->add('entry.time < ?', [TIME_NOW - $conditionData['greaterThan'] * 86400]);
-		}
-		if (isset($conditionData['lessThan'])) {
-			$objectList->getConditionBuilder()->add('entry.time > ?', [TIME_NOW - $conditionData['lessThan'] * 86400]);
-		}
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected function getIdentifier() {
-		return 'lexicon_createDateInterval';
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected function getLabel() {
-		return WCF::getLanguage()->get('wcf.acp.uzbot.lexicon.condition.create');
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function validate() {
-		if ($this->lessThan !== null) {
-			if ($this->getMinValue() !== null && $this->lessThan <= $this->getMinValue()) {
-				$this->errorMessage = 'wcf.condition.lessThan.error.minValue';
-				
-				throw new UserInputException('lessThan', 'minValue');
-			}
-			else if ($this->getMaxValue() !== null && $this->lessThan > $this->getMaxValue()) {
-				$this->errorMessage = 'wcf.condition.lessThan.error.maxValue';
-				
-				throw new UserInputException('lessThan', 'maxValue');
-			}
-		}
-		if ($this->greaterThan !== null) {
-			if ($this->getMinValue() !== null && $this->greaterThan < $this->getMinValue()) {
-				$this->errorMessage = 'wcf.condition.greaterThan.error.minValue';
-				
-				throw new UserInputException('greaterThan', 'minValue');
-			}
-			else if ($this->getMaxValue() !== null && $this->greaterThan >= $this->getMaxValue()) {
-				$this->errorMessage = 'wcf.condition.greaterThan.error.maxValue';
-				
-				throw new UserInputException('greaterThan', 'maxValue');
-			}
-		}
-		
-		if ($this->lessThan !== null && $this->greaterThan !== null && $this->greaterThan >= $this->lessThan) {
-			$this->errorMessage = 'wcf.condition.greaterThan.error.lessThan';
-			
-			throw new UserInputException('greaterThan', 'lessThan');
-		}
-	}
+class UzbotLexiconCreateDateIntervalCondition extends AbstractIntegerCondition implements IObjectListCondition
+{
+    /**
+     * @inheritDoc
+     */
+    protected $label = 'wcf.acp.uzbot.lexicon.condition.createTime';
+
+    /**
+     * @inheritDoc
+     */
+    protected $minValue = 0;
+
+    /**
+     * @inheritDoc
+     */
+    public function addObjectListCondition(DatabaseObjectList $objectList, array $conditionData)
+    {
+        if (!($objectList instanceof EntryList)) {
+            throw new InvalidArgumentException("Object list is no instance of '" . EntryList::class . "', instance of '" . \get_class($objectList) . "' given.");
+        }
+
+        if (isset($conditionData['greaterThan'])) {
+            $objectList->getConditionBuilder()->add('entry.time < ?', [TIME_NOW - $conditionData['greaterThan'] * 86400]);
+        }
+        if (isset($conditionData['lessThan'])) {
+            $objectList->getConditionBuilder()->add('entry.time > ?', [TIME_NOW - $conditionData['lessThan'] * 86400]);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getIdentifier()
+    {
+        return 'lexicon_createDateInterval';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getLabel()
+    {
+        return WCF::getLanguage()->get('wcf.acp.uzbot.lexicon.condition.create');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate()
+    {
+        if ($this->lessThan !== null) {
+            if ($this->getMinValue() !== null && $this->lessThan <= $this->getMinValue()) {
+                $this->errorMessage = 'wcf.condition.lessThan.error.minValue';
+
+                throw new UserInputException('lessThan', 'minValue');
+            } elseif ($this->getMaxValue() !== null && $this->lessThan > $this->getMaxValue()) {
+                $this->errorMessage = 'wcf.condition.lessThan.error.maxValue';
+
+                throw new UserInputException('lessThan', 'maxValue');
+            }
+        }
+        if ($this->greaterThan !== null) {
+            if ($this->getMinValue() !== null && $this->greaterThan < $this->getMinValue()) {
+                $this->errorMessage = 'wcf.condition.greaterThan.error.minValue';
+
+                throw new UserInputException('greaterThan', 'minValue');
+            } elseif ($this->getMaxValue() !== null && $this->greaterThan >= $this->getMaxValue()) {
+                $this->errorMessage = 'wcf.condition.greaterThan.error.maxValue';
+
+                throw new UserInputException('greaterThan', 'maxValue');
+            }
+        }
+
+        if ($this->lessThan !== null && $this->greaterThan !== null && $this->greaterThan >= $this->lessThan) {
+            $this->errorMessage = 'wcf.condition.greaterThan.error.lessThan';
+
+            throw new UserInputException('greaterThan', 'lessThan');
+        }
+    }
 }

--- a/files/lib/system/condition/uzbot/UzbotLexiconEditDateIntervalCondition.class.php
+++ b/files/lib/system/condition/uzbot/UzbotLexiconEditDateIntervalCondition.class.php
@@ -1,5 +1,28 @@
 <?php
+
+/*
+ * Copyright by Udo Zaydowicz.
+ * Modified by SoftCreatR.dev.
+ *
+ * License: http://opensource.org/licenses/lgpl-license.php
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 namespace lexicon\system\condition\uzbot;
+
+use InvalidArgumentException;
 use lexicon\data\entry\Entry;
 use lexicon\data\entry\EntryList;
 use wcf\data\condition\Condition;
@@ -11,85 +34,84 @@ use wcf\system\WCF;
 
 /**
  * Condition implementation for an integer to day property of an entry.
- * 
- * @author		2019-2022 Zaydowicz
- * @license		GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package		com.uz.wcf.bot3.lexicon
  */
-class UzbotLexiconEditDateIntervalCondition extends AbstractIntegerCondition implements IObjectListCondition {
-	/**
-	 * @inheritDoc
-	 */
-	protected $label = 'wcf.acp.uzbot.lexicon.condition.editTime';
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected $minValue = 0;
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function addObjectListCondition(DatabaseObjectList $objectList, array $conditionData) {
-		if (!($objectList instanceof EntryList)) {
-			throw new \InvalidArgumentException("Object list is no instance of '".EntryList::class."', instance of '".get_class($objectList)."' given.");
-		}
-		
-		if (isset($conditionData['greaterThan'])) {
-			$objectList->getConditionBuilder()->add('entry.lastEditTime > ? AND entry.lastEditTime < ?', [0, TIME_NOW - $conditionData['greaterThan'] * 86400]);
-		}
-		if (isset($conditionData['lessThan'])) {
-			$objectList->getConditionBuilder()->add('entry.lastEditTime > ?', [TIME_NOW - $conditionData['lessThan'] * 86400]);
-		}
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected function getIdentifier() {
-		return 'lexicon_editDateInterval';
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected function getLabel() {
-		return WCF::getLanguage()->get('wcf.acp.uzbot.lexicon.condition.edit');
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function validate() {
-		if ($this->lessThan !== null) {
-			if ($this->getMinValue() !== null && $this->lessThan <= $this->getMinValue()) {
-				$this->errorMessage = 'wcf.condition.lessThan.error.minValue';
-				
-				throw new UserInputException('lessThan', 'minValue');
-			}
-			else if ($this->getMaxValue() !== null && $this->lessThan > $this->getMaxValue()) {
-				$this->errorMessage = 'wcf.condition.lessThan.error.maxValue';
-				
-				throw new UserInputException('lessThan', 'maxValue');
-			}
-		}
-		if ($this->greaterThan !== null) {
-			if ($this->getMinValue() !== null && $this->greaterThan < $this->getMinValue()) {
-				$this->errorMessage = 'wcf.condition.greaterThan.error.minValue';
-				
-				throw new UserInputException('greaterThan', 'minValue');
-			}
-			else if ($this->getMaxValue() !== null && $this->greaterThan >= $this->getMaxValue()) {
-				$this->errorMessage = 'wcf.condition.greaterThan.error.maxValue';
-				
-				throw new UserInputException('greaterThan', 'maxValue');
-			}
-		}
-		
-		if ($this->lessThan !== null && $this->greaterThan !== null && $this->greaterThan >= $this->lessThan) {
-			$this->errorMessage = 'wcf.condition.greaterThan.error.lessThan';
-			
-			throw new UserInputException('greaterThan', 'lessThan');
-		}
-	}
+class UzbotLexiconEditDateIntervalCondition extends AbstractIntegerCondition implements IObjectListCondition
+{
+    /**
+     * @inheritDoc
+     */
+    protected $label = 'wcf.acp.uzbot.lexicon.condition.editTime';
+
+    /**
+     * @inheritDoc
+     */
+    protected $minValue = 0;
+
+    /**
+     * @inheritDoc
+     */
+    public function addObjectListCondition(DatabaseObjectList $objectList, array $conditionData)
+    {
+        if (!($objectList instanceof EntryList)) {
+            throw new InvalidArgumentException("Object list is no instance of '" . EntryList::class . "', instance of '" . \get_class($objectList) . "' given.");
+        }
+
+        if (isset($conditionData['greaterThan'])) {
+            $objectList->getConditionBuilder()->add('entry.lastEditTime > ? AND entry.lastEditTime < ?', [0, TIME_NOW - $conditionData['greaterThan'] * 86400]);
+        }
+        if (isset($conditionData['lessThan'])) {
+            $objectList->getConditionBuilder()->add('entry.lastEditTime > ?', [TIME_NOW - $conditionData['lessThan'] * 86400]);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getIdentifier()
+    {
+        return 'lexicon_editDateInterval';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getLabel()
+    {
+        return WCF::getLanguage()->get('wcf.acp.uzbot.lexicon.condition.edit');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate()
+    {
+        if ($this->lessThan !== null) {
+            if ($this->getMinValue() !== null && $this->lessThan <= $this->getMinValue()) {
+                $this->errorMessage = 'wcf.condition.lessThan.error.minValue';
+
+                throw new UserInputException('lessThan', 'minValue');
+            } elseif ($this->getMaxValue() !== null && $this->lessThan > $this->getMaxValue()) {
+                $this->errorMessage = 'wcf.condition.lessThan.error.maxValue';
+
+                throw new UserInputException('lessThan', 'maxValue');
+            }
+        }
+        if ($this->greaterThan !== null) {
+            if ($this->getMinValue() !== null && $this->greaterThan < $this->getMinValue()) {
+                $this->errorMessage = 'wcf.condition.greaterThan.error.minValue';
+
+                throw new UserInputException('greaterThan', 'minValue');
+            } elseif ($this->getMaxValue() !== null && $this->greaterThan >= $this->getMaxValue()) {
+                $this->errorMessage = 'wcf.condition.greaterThan.error.maxValue';
+
+                throw new UserInputException('greaterThan', 'maxValue');
+            }
+        }
+
+        if ($this->lessThan !== null && $this->greaterThan !== null && $this->greaterThan >= $this->lessThan) {
+            $this->errorMessage = 'wcf.condition.greaterThan.error.lessThan';
+
+            throw new UserInputException('greaterThan', 'lessThan');
+        }
+    }
 }

--- a/files/lib/system/condition/uzbot/UzbotLexiconStateCondition.class.php
+++ b/files/lib/system/condition/uzbot/UzbotLexiconStateCondition.class.php
@@ -1,5 +1,28 @@
 <?php
+
+/*
+ * Copyright by Udo Zaydowicz.
+ * Modified by SoftCreatR.dev.
+ *
+ * License: http://opensource.org/licenses/lgpl-license.php
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 namespace lexicon\system\condition\uzbot;
+
+use InvalidArgumentException;
 use lexicon\data\entry\Entry;
 use lexicon\data\entry\EntryList;
 use wcf\data\condition\Condition;
@@ -14,199 +37,218 @@ use wcf\system\WCF;
 
 /**
  * Condition implementation for the state of an entry.
- * 
- * @author		2019-2022 Zaydowicz
- * @license		GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package		com.uz.wcf.bot3.lexicon
  */
-class UzbotLexiconStateCondition extends AbstractSingleFieldCondition implements IContentCondition, IObjectCondition, IObjectListCondition {
-	/**
-	 * @inheritDoc
-	 */
-	protected $label = 'wcf.acp.uzbot.lexicon.condition.state';
-	
-	/**
-	 * values of the possible state
-	 */
-	public $states = [
-			'isDisabled' => 0,
-			'isEnabled' => 0,
-			'isCompleted' => 0,
-			'isNotCompleted' => 0,
-			'hasLabels' => 0,
-			'hasNoLabels' => 0,
-			'isEdited' => 0,
-			'isNotEdited' => 0,
-	];
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function addObjectListCondition(DatabaseObjectList $objectList, array $conditionData) {
-		if (!($objectList instanceof EntryList)) {
-			throw new \InvalidArgumentException("Object list is no instance of '".EntryList::class."', instance of '".get_class($objectList)."' given.");
-		}
-		
-		if (isset($conditionData['isDisabled'])) {
-			$objectList->getConditionBuilder()->add('entry.isDisabled = ?', [$conditionData['isDisabled']]);
-		}
-		
-		if (isset($conditionData['isCompleted'])) {
-			$objectList->getConditionBuilder()->add('entry.isCompleted = ?', [$conditionData['isCompleted']]);
-		}
-		
-		if (isset($conditionData['hasLabels'])) {
-			$objectList->getConditionBuilder()->add('entry.hasLabels = ?', [$conditionData['hasLabels']]);
-		}
-		
-		if (isset($conditionData['isEdited'])) {
-			if ($conditionData['isEdited']) {
-				$objectList->getConditionBuilder()->add('entry.lastEditTime > ?', [0]);
-			}
-			else {
-				$objectList->getConditionBuilder()->add('entry.lastEditTime = ?', [0]);
-			}
-		}
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function checkObject(DatabaseObject $object, array $conditionData) {
-		if (!($object instanceof Entry) && (!($object instanceof DatabaseObjectDecorator) || !($object->getDecoratedObject() instanceof Entry))) {
-			throw new \InvalidArgumentException("Object is no (decorated) instance of '".Entry::class."', instance of '".get_class($object)."' given.");
-		}
-		
-		$simpleStates = ['isDisabled', 'isCompleted', 'hasLabels', 'isEdited'];
-		foreach ($simpleStates as $state) {
-			if (isset($conditionData[$state]) && $object->$state != $conditionData[$state]) {
-				return false;
-			}
-		}
-		
-		return true;
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function getData() {
-		$data = [];
-		
-		if ($this->states['isDisabled']) $data['isDisabled'] = 1;
-		else if ($this->states['isEnabled']) $data['isDisabled'] = 0;
-		
-		if ($this->states['isCompleted']) $data['isCompleted'] = 1;
-		else if ($this->states['isNotCompleted']) $data['isCompleted'] = 0;
-		
-		if ($this->states['hasLabels']) $data['hasLabels'] = 1;
-		else if ($this->states['hasNoLabels']) $data['hasLabels'] = 0;
-		
-		if ($this->states['isEdited']) $data['isEdited'] = 1;
-		else if ($this->states['isNotEdited']) $data['isEdited'] = 0;
-		
-		if (!empty($data)) {
-			return $data;
-		}
-		
-		return null;
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected function getFieldElement() {
-		$fieldElement = '';
-		
-		foreach ($this->states as $state => $value) {
-			$fieldElement .= '<label><input type="checkbox" name="uzbotLexiconEntry' . ucfirst($state) . '" value="1"' . ($value ? ' checked' : '') . '> ' . WCF::getLanguage()->get('wcf.acp.uzbot.lexicon.entry.condition.state.' . $state) . "</label>\n";
-		}
-		
-		return $fieldElement;
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function readFormParameters() {
-		foreach ($this->states as $state => &$value) {
-			if (isset($_POST['uzbotLexiconEntry'.ucfirst($state)])) $value = 1;
-		}
-		unset($value);
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function reset() {
-		foreach ($this->states as $state => $value) {
-			$this->states[$state] = 0;
-		}
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function setData(Condition $condition) {
-		$isDisabled = $condition->isDisabled;
-		if ($isDisabled !== null) {
-			$this->states['isDisabled'] = $isDisabled;
-			$this->states['isEnabled'] = 1 - $isDisabled;
-		}
-		
-		$isCompleted = $condition->isCompleted;
-		if ($isCompleted !== null) {
-			$this->states['isCompleted'] = $isCompleted;
-			$this->states['isNotCompleted'] = 1 - $isCompleted;
-		}
-		
-		$hasLabels = $condition->hasLabels;
-		if ($hasLabels !== null) {
-			$this->states['hasLabels'] = $hasLabels;
-			$this->states['hasNoLabels'] = 1 - $hasLabels;
-		}
-		
-		$isEdited = $condition->isEdited;
-		if ($isEdited !== null) {
-			$this->states['isEdited'] = $isEdited;
-			$this->states['isNotEdited'] = 1 - $isEdited;
-		}
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function validate() {
-		if ($this->states['isDisabled'] && $this->states['isEnabled']) {
-			$this->errorMessage = 'wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled.error.conflict';
-			
-			throw new UserInputException('isDisabled', 'conflict');
-		}
-		
-		if ($this->states['isCompleted'] && $this->states['isNotCompleted']) {
-			$this->errorMessage = 'wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted.error.conflict';
-			
-			throw new UserInputException('isCompleted', 'conflict');
-		}
-		
-		if ($this->states['hasLabels'] && $this->states['hasNoLabels']) {
-			$this->errorMessage = 'wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels.error.conflict';
-			
-			throw new UserInputException('hasLabels', 'conflict');
-		}
-		
-		if ($this->states['isEdited'] && $this->states['isNotEdited']) {
-			$this->errorMessage = 'wcf.acp.uzbot.lexicon.entry.condition.state.isEdited.error.conflict';
-			
-			throw new UserInputException('isEdited', 'conflict');
-		}
-	}
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function showContent(Condition $condition) {
-		// don't need it
-		return null;
-	}
+class UzbotLexiconStateCondition extends AbstractSingleFieldCondition implements IContentCondition, IObjectCondition, IObjectListCondition
+{
+    /**
+     * @inheritDoc
+     */
+    protected $label = 'wcf.acp.uzbot.lexicon.condition.state';
+
+    /**
+     * values of the possible state
+     */
+    public $states = [
+        'isDisabled' => 0,
+        'isEnabled' => 0,
+        'isCompleted' => 0,
+        'isNotCompleted' => 0,
+        'hasLabels' => 0,
+        'hasNoLabels' => 0,
+        'isEdited' => 0,
+        'isNotEdited' => 0,
+    ];
+
+    /**
+     * @inheritDoc
+     */
+    public function addObjectListCondition(DatabaseObjectList $objectList, array $conditionData)
+    {
+        if (!($objectList instanceof EntryList)) {
+            throw new InvalidArgumentException("Object list is no instance of '" . EntryList::class . "', instance of '" . \get_class($objectList) . "' given.");
+        }
+
+        if (isset($conditionData['isDisabled'])) {
+            $objectList->getConditionBuilder()->add('entry.isDisabled = ?', [$conditionData['isDisabled']]);
+        }
+
+        if (isset($conditionData['isCompleted'])) {
+            $objectList->getConditionBuilder()->add('entry.isCompleted = ?', [$conditionData['isCompleted']]);
+        }
+
+        if (isset($conditionData['hasLabels'])) {
+            $objectList->getConditionBuilder()->add('entry.hasLabels = ?', [$conditionData['hasLabels']]);
+        }
+
+        if (isset($conditionData['isEdited'])) {
+            if ($conditionData['isEdited']) {
+                $objectList->getConditionBuilder()->add('entry.lastEditTime > ?', [0]);
+            } else {
+                $objectList->getConditionBuilder()->add('entry.lastEditTime = ?', [0]);
+            }
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function checkObject(DatabaseObject $object, array $conditionData)
+    {
+        if (!($object instanceof Entry) && (!($object instanceof DatabaseObjectDecorator) || !($object->getDecoratedObject() instanceof Entry))) {
+            throw new InvalidArgumentException("Object is no (decorated) instance of '" . Entry::class . "', instance of '" . \get_class($object) . "' given.");
+        }
+
+        $simpleStates = ['isDisabled', 'isCompleted', 'hasLabels', 'isEdited'];
+        foreach ($simpleStates as $state) {
+            if (isset($conditionData[$state]) && $object->{$state} != $conditionData[$state]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getData()
+    {
+        $data = [];
+
+        if ($this->states['isDisabled']) {
+            $data['isDisabled'] = 1;
+        } elseif ($this->states['isEnabled']) {
+            $data['isDisabled'] = 0;
+        }
+
+        if ($this->states['isCompleted']) {
+            $data['isCompleted'] = 1;
+        } elseif ($this->states['isNotCompleted']) {
+            $data['isCompleted'] = 0;
+        }
+
+        if ($this->states['hasLabels']) {
+            $data['hasLabels'] = 1;
+        } elseif ($this->states['hasNoLabels']) {
+            $data['hasLabels'] = 0;
+        }
+
+        if ($this->states['isEdited']) {
+            $data['isEdited'] = 1;
+        } elseif ($this->states['isNotEdited']) {
+            $data['isEdited'] = 0;
+        }
+
+        if (!empty($data)) {
+            return $data;
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getFieldElement()
+    {
+        $fieldElement = '';
+
+        foreach ($this->states as $state => $value) {
+            $fieldElement .= '<label><input type="checkbox" name="uzbotLexiconEntry' . \ucfirst($state) . '" value="1"' . ($value ? ' checked' : '') . '> ' . WCF::getLanguage()->get('wcf.acp.uzbot.lexicon.entry.condition.state.' . $state) . "</label>\n";
+        }
+
+        return $fieldElement;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function readFormParameters()
+    {
+        foreach ($this->states as $state => &$value) {
+            if (isset($_POST['uzbotLexiconEntry' . \ucfirst($state)])) {
+                $value = 1;
+            }
+        }
+        unset($value);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reset()
+    {
+        foreach ($this->states as $state => $value) {
+            $this->states[$state] = 0;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setData(Condition $condition)
+    {
+        $isDisabled = $condition->isDisabled;
+        if ($isDisabled !== null) {
+            $this->states['isDisabled'] = $isDisabled;
+            $this->states['isEnabled'] = 1 - $isDisabled;
+        }
+
+        $isCompleted = $condition->isCompleted;
+        if ($isCompleted !== null) {
+            $this->states['isCompleted'] = $isCompleted;
+            $this->states['isNotCompleted'] = 1 - $isCompleted;
+        }
+
+        $hasLabels = $condition->hasLabels;
+        if ($hasLabels !== null) {
+            $this->states['hasLabels'] = $hasLabels;
+            $this->states['hasNoLabels'] = 1 - $hasLabels;
+        }
+
+        $isEdited = $condition->isEdited;
+        if ($isEdited !== null) {
+            $this->states['isEdited'] = $isEdited;
+            $this->states['isNotEdited'] = 1 - $isEdited;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate()
+    {
+        if ($this->states['isDisabled'] && $this->states['isEnabled']) {
+            $this->errorMessage = 'wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled.error.conflict';
+
+            throw new UserInputException('isDisabled', 'conflict');
+        }
+
+        if ($this->states['isCompleted'] && $this->states['isNotCompleted']) {
+            $this->errorMessage = 'wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted.error.conflict';
+
+            throw new UserInputException('isCompleted', 'conflict');
+        }
+
+        if ($this->states['hasLabels'] && $this->states['hasNoLabels']) {
+            $this->errorMessage = 'wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels.error.conflict';
+
+            throw new UserInputException('hasLabels', 'conflict');
+        }
+
+        if ($this->states['isEdited'] && $this->states['isNotEdited']) {
+            $this->errorMessage = 'wcf.acp.uzbot.lexicon.entry.condition.state.isEdited.error.conflict';
+
+            throw new UserInputException('isEdited', 'conflict');
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function showContent(Condition $condition)
+    {
+        // don't need it
+        return null;
+    }
 }

--- a/files/lib/system/condition/uzbot/UzbotLexiconUsernameCondition.class.php
+++ b/files/lib/system/condition/uzbot/UzbotLexiconUsernameCondition.class.php
@@ -1,40 +1,60 @@
 <?php
+
+/*
+ * Copyright by Udo Zaydowicz.
+ * Modified by SoftCreatR.dev.
+ *
+ * License: http://opensource.org/licenses/lgpl-license.php
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 namespace lexicon\system\condition\uzbot;
+
 use lexicon\data\entry\Entry;
 use wcf\system\condition\AbstractObjectTextPropertyCondition;
 use wcf\system\WCF;
 
 /**
  * Condition implementation for the name of the user who created an entry.
- * 
- * @author		2019-2022 Zaydowicz
- * @license		GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package		com.uz.wcf.bot3.lexicon
  */
-class UzbotLexiconUsernameCondition extends AbstractObjectTextPropertyCondition {
-	/**
-	 * @inheritDoc
-	 */
-	protected $className = Entry::class;
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected $label = 'wcf.acp.uzbot.lexicon.condition.username';
-	protected $description = 'wcf.acp.uzbot.lexicon.condition.username.description';
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected $fieldName = 'lexiconEntryUsername';
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected $propertyName = 'username';
-	
-	/**
-	 * @inheritDoc
-	 */
-	protected $supportsMultipleValues = true;
+class UzbotLexiconUsernameCondition extends AbstractObjectTextPropertyCondition
+{
+    /**
+     * @inheritDoc
+     */
+    protected $className = Entry::class;
+
+    /**
+     * @inheritDoc
+     */
+    protected $label = 'wcf.acp.uzbot.lexicon.condition.username';
+
+    protected $description = 'wcf.acp.uzbot.lexicon.condition.username.description';
+
+    /**
+     * @inheritDoc
+     */
+    protected $fieldName = 'lexiconEntryUsername';
+
+    /**
+     * @inheritDoc
+     */
+    protected $propertyName = 'username';
+
+    /**
+     * @inheritDoc
+     */
+    protected $supportsMultipleValues = true;
 }

--- a/files/lib/system/cronjob/UzbotLexiconModificationCronjob.class.php
+++ b/files/lib/system/cronjob/UzbotLexiconModificationCronjob.class.php
@@ -1,13 +1,35 @@
-<?php 
+<?php
+
+/*
+ * Copyright by Udo Zaydowicz.
+ * Modified by SoftCreatR.dev.
+ *
+ * License: http://opensource.org/licenses/lgpl-license.php
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 namespace lexicon\system\cronjob;
+
 use lexicon\data\entry\Entry;
 use lexicon\data\entry\EntryAction;
 use lexicon\data\entry\EntryEditor;
 use lexicon\data\entry\EntryList;
 use wcf\data\cronjob\Cronjob;
 use wcf\data\user\User;
-use wcf\data\uzbot\UzbotEditor;
 use wcf\data\uzbot\log\UzbotLogEditor;
+use wcf\data\uzbot\UzbotEditor;
 use wcf\system\background\BackgroundQueueHandler;
 use wcf\system\background\uzbot\NotifyScheduleBackgroundJob;
 use wcf\system\cache\builder\UzbotValidBotCacheBuilder;
@@ -22,471 +44,493 @@ use wcf\system\WCF;
 
 /**
  * Lexicon modification cronjob for Bot.
- *  
- * @author		2019-2022 Zaydowicz
- * @license		GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package		com.uz.wcf.bot3.lexicon
  */
-class UzbotLexiconModificationCronjob extends AbstractCronjob {
-	/**
-	 * list with entries to be modified
-	 */
-	protected $entryList = null;
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function execute(Cronjob $cronjob) {
-		parent::execute($cronjob);
-		
-		if (!MODULE_UZBOT) return;
-		
-		// Read all active, valid bots, abort if none
-		$bots = UzbotValidBotCacheBuilder::getInstance()->getData(array('typeDes' => 'lexicon_modification'));
-		if (empty($bots)) return;
-		
-		$defaultLanguage = LanguageFactory::getInstance()->getLanguage(LanguageFactory::getInstance()->getDefaultLanguageID());
-		
-		// Step through all bots and get entries to be modified
-		foreach ($bots as $bot) {
-			// set data
-			$modifications = unserialize($bot->lexiconModificationData);
-			$userData = [];
-			
-			// check executer
-			$user = new User($modifications['lexiconModificationExecuterID']);
-			if (!$user->userID) {
-				$editor = new UzbotEditor($bot);
-				$editor->update(['isDisabled' => 1]);
-				UzbotEditor::resetCache();
-				
-				if ($bot->enableLog) {
-					UzbotLogEditor::create([
-							'bot' => $bot,
-							'count' => 0,
-							'status' => 2,
-							'additionalData' => $defaultLanguage->get('wcf.acp.uzbot.lexicon.error.executerInvalid')
-					]);
-				}
-				continue;
-			}
-			
-			// change user
-			$oldUser = WCF::getUser();
-			WCF::getSession()->changeUser(new User($modifications['lexiconModificationExecuterID']), true);
-			
-			// get all entryIDs matching conditions
-			$conditions = ConditionHandler::getInstance()->getConditions('com.uz.wcf.bot.condition.lexicon', $bot->botID);
-			$conditionEntryIDs = [];
-			if (count($conditions)) {
-				$entryList = new EntryList();
-				foreach ($conditions as $condition) {
-					$condition->getObjectType()->getProcessor()->addObjectListCondition($entryList, $condition->conditionData);
-				}
-				$entryList->readObjectIDs();
-				$conditionEntryIDs = $entryList->getObjectIDs();
-				if (empty($conditionEntryIDs)) $conditionEntryIDs[] = 0;
-			}
-			$conditionCount = count($conditionEntryIDs);
-			
-			// same for labels
-			$labelEntryIDs = [];
-			$useLabels = 0;
-			$labels = UzbotConditionLabelObjectHandler::getInstance()->getAssignedLabels([$bot->botID], false);
-			if (!empty($labels)) {
-				$useLabels = 1;
-				$labelIDs = [];
-				foreach ($labels as $temp) {
-					foreach ($temp as $labelID => $label) {
-						$labelIDs[] = $labelID;
-					}
-				}
-				
-				$objectType = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry');
-				$entryList = new EntryList();
-				foreach ($labelIDs as $labelID) {
-					$entryList->getConditionBuilder()->add('entry.entryID IN (SELECT objectID FROM wcf'.WCF_N.'_label_object WHERE objectTypeID = ? AND labelID = ?)', [$objectType->objectTypeID, $labelID]);
-				}
-				$entryList->readObjectIDs();
-				$labelEntryIDs = $entryList->getObjectIDs();
-				if (empty($labelEntryIDs)) $labelEntryIDs[] = 0;
-			}
-			$labelCount = count($labelEntryIDs);
-			
-			// category
-			$categoryEntryIDs = [];
-			if ($modifications['lexiconModificationCategoryID']) {
-				$entryList = new EntryList();
-				$entryList->getConditionBuilder()->add('entry.entryID IN (SELECT entryID FROM lexicon'.WCF_N.'_entry_to_category WHERE categoryID = ?)', [$modifications['lexiconModificationCategoryID']]);
-				$entryList->readObjectIDs();
-				$categoryEntryIDs = $entryList->getObjectIDs();
-				if (empty($categoryEntryIDs)) $categoryEntryIDs[] = 0;
-			}
-			$categoryCount = count($categoryEntryIDs);
-			
-			// merge entryIDs
-			if (!$conditionCount && !$labelCount && !$categoryCount) {	// all entries
-				$entryList = new EntryList();
-				$entryList->readObjectIDs();
-				$entryIDs = $entryList->getObjectIDs();
-			}
-			elseif ((isset($conditionEntryIDs[0]) && $conditionEntryIDs[0] == 0) || (isset($labelEntryIDs[0]) && $labelEntryIDs[0] == 0) || (isset($categoryEntryIDs[0]) && $categoryEntryIDs[0] == 0)) {
-				$entryIDs[0] = 0;
-			}
-			else {
-				$tempArray[] = $conditionEntryIDs;
-				$tempArray[] = $labelEntryIDs;
-				$tempArray[] = $categoryEntryIDs;
-				
-				$tempArray = array_filter($tempArray);
-				$entryIDs = array_shift($tempArray);
-				foreach($tempArray as $array){
-					$entryIDs = array_intersect($entryIDs, $array);
-				}
-			}
-			
-			// if no entries, log and abort
-			$entryCount = count($entryIDs);
-			
-			// log found entries (not action)
-			if ($bot->enableLog) {
-				if ($entryCount == 1 && isset($entryIDs[0]) && $entryIDs[0] == 0) $count = 0;
-				else $count = $entryCount;
-				$result = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.lexicon.entry.affected', ['count' => $count]);
-				
-				if (!$bot->testMode) {
-					UzbotLogEditor::create([
-							'bot' => $bot,
-							'count' => $count,
-							'additionalData' => $result
-					]);
-				}
-				else {
-					UzbotLogEditor::create([
-							'bot' => $bot,
-							'count' => $count,
-							'testMode' => 1,
-							'additionalData' => serialize(['', '', $result])
-					]);
-				}
-			}
-			
-			// abort if no entries
-			if ($entryCount == 1 && isset($entryIDs[0]) && $entryIDs[0] == 0) {
-				// Reset to old user
-				WCF::getSession()->changeUser($oldUser, true);
-				continue;
-			}
-			
-			// get actionLabelIDs and related data
-			$actionLabelIDs = [];
-			$actionLabels = UzbotActionLabelObjectHandler::getInstance()->getAssignedLabels([$bot->botID], false);
-			if (count($actionLabels)) {
-				foreach ($actionLabels as $temp) {
-					foreach ($temp as $label) {
-						$actionLabelIDs[] = $label->labelID;
-					}
-				}
-			}
-			$objectType = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry');
-			$labelObjectTypeID = $objectType->objectTypeID;
-			
-			// step through entries until at least one entry was modified
-			$found = 0;
-			for ($i = 0; $i < $entryCount; $i += UZBOT_DATA_LIMIT_LEXICON) {
-				$ids = array_slice($entryIDs, $i, UZBOT_DATA_LIMIT_LEXICON);
-				
-				// step through action in sequence of add form
-				if ($modifications['lexiconModificationEnable']) {
-					$entryList = new EntryList();
-					$entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
-					$entryList->getConditionBuilder()->add('entry.isDisabled = ?', [1]);
-					$entryList->readObjects();
-					$entries = $entryList->getObjects();
-					if (count($entries)) {
-						$found = 1;
-						$this->executeBot($bot, $entries, 'enable', $defaultLanguage);
-					}
-				}
-				
-				if ($modifications['lexiconModificationDisable']) {
-					$entryList = new EntryList();
-					$entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
-					$entryList->getConditionBuilder()->add('entry.isDisabled = ?', [0]);
-					$entryList->readObjects();
-					$entries = $entryList->getObjects();
-					if (count($entries)) {
-						$found = 1;
-						$this->executeBot($bot, $entries, 'disable', $defaultLanguage);
-					}
-				}
-				
-				if ($modifications['lexiconModificationComplete']) {
-					$entryList = new EntryList();
-					$entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
-					$entryList->getConditionBuilder()->add('entry.isCompleted = ?', [0]);
-					$entryList->readObjects();
-					$entries = $entryList->getObjects();
-					if (count($entries)) {
-						$found = 1;
-						$this->executeBot($bot, $entries, 'done', $defaultLanguage);
-					}
-				}
-				
-				if ($modifications['lexiconModificationUncomplete']) {
-					$entryList = new EntryList();
-					$entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
-					$entryList->getConditionBuilder()->add('entry.isCompleted = ?', [1]);
-					$entryList->readObjects();
-					$entries = $entryList->getObjects();
-					if (count($entries)) {
-						$found = 1;
-						$this->executeBot($bot, $entries, 'undone', $defaultLanguage);
-					}
-				}
-				
-				if ($modifications['lexiconModificationSetLabel']) {
-					// user wants to delete labels
-					if (!count($actionLabelIDs)) {
-						$entryList = new EntryList();
-						$entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
-						$entryList->getConditionBuilder()->add('entry.hasLabels = ?', [1]);
-						$entryList->readObjects();
-						$entries = $entryList->getObjects();
-						if (count($entries)) {
-							$found = 1;
-							$this->executeBot($bot, $entries, 'deleteLabels', $defaultLanguage);
-						}
-					}
-					
-					// user wants to add / change labels
-					else {
-						// read actual label assignment and get entries to be modified
-						$assign = $modifyID = [];
-						$conditionBuilder = new PreparedStatementConditionBuilder();
-						$conditionBuilder->add('objectTypeID = ?', [$labelObjectTypeID]);
-						$conditionBuilder->add('objectID IN (?)', [$ids]);
-						$sql = "SELECT 	objectID, labelID
-								FROM	wcf".WCF_N."_label_object
-								".$conditionBuilder;
-						$statement = WCF::getDB()->prepareStatement($sql);
-						$statement->execute($conditionBuilder->getParameters());
-						while ($row = $statement->fetchArray()) {
-							$assign[$row['objectID']][] = $row['labelID'];
-						}
-						
-						$modifyID = [];
-						foreach ($ids as $entryID) {
-							if (!isset($assign[$entryID])) {
-								$modifyID[] = $entryID;
-								continue;
-							}
-							if (count($assign[$entryID]) != count($actionLabelIDs)) {
-								$modifyID[] = $entryID;
-								continue;
-							}
-							if (!empty(array_diff($actionLabelIDs, $assign[$entryID]))) {
-								$modifyID[] = $entryID;
-							}
-						}
-						
-						if (count($modifyID)) {
-							$entryList = new EntryList();
-							$entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$modifyID]);
-							$entryList->readObjects();
-							$entries = $entryList->getObjects();
-							if (count($entries)) {
-								$found = 1;
-								$this->executeBot($bot, $entries, 'setLabels', $defaultLanguage, $actionLabels);
-							}
-						}
-					}
-				}
-				
-				// break if entry was found
-				if ($found) break;
-			}
-			
-			// Reset to old user
-			WCF::getSession()->changeUser($oldUser, true);
-		}
-	}
-	
-	protected function executeBot($bot, $entries, $action, $defaultLanguage, $labels = []) {
-		$affectedUserIDs = $countToUserID = $placeholders = $entryIDs = $entryToUser = [];
-		
-		if (!count($entries)) {
-			if ($bot->enableLog) {
-				if (!$bot->testMode) {
-					UzbotLogEditor::create([
-							'bot' => $bot,
-							'count' => 0,
-							'additionalData' => $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.lexicon.entry.modified', [
-									'action' => $defaultLanguage->get('wcf.acp.uzbot.lexicon.entryModification.action.' . $action),
-									'entryIDs' => ''
-							])
-					]);
-					
-					UzbotLogEditor::create([
-							'bot' => $bot,
-							'count' => count($affectedUserIDs),
-							'additionalData' => $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.user.affected', [
-									'total' => 0,
-									'userIDs' => ''
-							])
-					]);
-				}
-				else {
-					$result = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.test', [
-							'objects' => 0,
-							'users' => 0,
-							'userIDs' => ''
-					]);
-					if (mb_strlen($result) > 64000) $result = mb_substr($result, 0, 64000) . ' ...';
-					UzbotLogEditor::create([
-							'bot' => $bot,
-							'count' => count($entryIDs),
-							'testMode' => 1,
-							'additionalData' => serialize(['', '', $result])
-					]);
-				}
-			}
-			return;
-		}
-		
-		foreach ($entries as $entry) {
-			$entryIDs[] = $entry->entryID;
-			
-			if (!$entry->userID) continue;
-			
-			$entryToUser[$entry->entryID] = $entry->userID;
-			
-			$affectedUserIDs[] = $entry->userID;
-			if (isset($countToUserID[$entry->userID])) $countToUserID[$entry->userID] ++;
-			else $countToUserID[$entry->userID] = 1;
-		}
-		
-		$affectedUserIDs = array_unique($affectedUserIDs);
-		
-		// change user for action + execute unless test mode
-		if (!$bot->testMode) {
-			if ($action != 'setLabels' && $action != 'deleteLabels') {
-				$entryAction = new EntryAction($entries, $action);
-				$entryAction->executeAction();
-			}
-			else {
-				// label object type
-				$objectType = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry');
-				$objectTypeID = $objectType->objectTypeID;
-				
-				// delete ...
-				if ($action == 'deleteLabels') {
-					$objectTypeID = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry')->objectTypeID;
-					$oldLabels = LabelHandler::getInstance()->getAssignedLabels($objectTypeID, $entryIDs);
-					
-					// remove labels
-					foreach ($entries as $entry) {
-						LabelHandler::getInstance()->setLabels([], $objectTypeID, $entry->entryID);
-						
-						// update hasLabels flag
-						$editor = new EntryEditor($entry);
-						$editor->update(['hasLabels' => 0]);
-					}
-				}
-				
-				// set ...
-				if ($action == 'setLabels') {
-					foreach ($labels as $temp) {
-						foreach ($temp as $label) {
-							$labelIDs[] = $label->labelID;
-						}
-					}
-					$botLabels = $labels;
-					$botLabelIDs = $labelIDs;
-					
-					// almost same as above
-					$objectTypeID = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry')->objectTypeID;
-					$oldLabels = LabelHandler::getInstance()->getAssignedLabels($objectTypeID, $entryIDs);
-					
-					foreach ($entries as $entry) {
-						LabelHandler::getInstance()->setLabels($botLabelIDs, $objectTypeID, $entry->entryID);
-						
-						$editor = new EntryEditor($entry);
-						$editor->update(['hasLabels' => !empty($botLabelIDs) ? 1 : 0]);
-					}
-				}
-			}
-		}
-		
-		if ($bot->enableLog) {
-			$result1 = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.lexicon.entry.modified', [
-					'action' => $defaultLanguage->get('wcf.acp.uzbot.lexicon.entryModification.action.' . $action),
-					'entryIDs' => implode(', ', $entryIDs)
-			]);
-			if (mb_strlen($result1) > 64000) $result1 = mb_substr($result1, 0, 64000) . ' ...';
-			
-			$result2 = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.user.affected', [
-					'total' => count($affectedUserIDs),
-					'userIDs' => implode(', ', $affectedUserIDs)
-			]);
-			if (mb_strlen($result2) > 64000) $result2 = mb_substr($result2, 0, 64000) . ' ...';
-			
-			UzbotLogEditor::create([
-					'bot' => $bot,
-					'testMode' => !$bot->testMode ? 0 : 1,
-					'count' => count($entryIDs),
-					'additionalData' => !$bot->testMode ? $result1 : serialize(['', '', $result1])
-			]);
-			
-			UzbotLogEditor::create([
-					'bot' => $bot,
-					'testMode' => !$bot->testMode ? 0 : 1,
-					'count' => count($affectedUserIDs),
-					'additionalData' => !$bot->testMode ? $result2 : serialize(['', '', $result2])
-			]);
-		}
-		
-		// check for and prepare notification
-		if ($bot->notifyID) {
-			$notify = $bot->checkNotify(true, true);
-			if ($notify === null) return;
-			
-			$placeholders['count'] = count($entryIDs);
-			$placeholders['object-ids'] = implode(', ', $entryIDs);
-			$placeholders['action'] = $defaultLanguage->get('wcf.acp.uzbot.lexicon.entryModification.action.' . $action);
-			
-			// test mode
-			$testUserIDs = $testToUserIDs = [];
-			if (count($affectedUserIDs)) {
-				$userID = reset($affectedUserIDs);
-				$testUserIDs[] = $userID;
-				$testToUserIDs[$userID] = $countToUserID[$userID];
-			}
-			
-			// send to scheduler, if not test mode
-			if ($bot->testMode) {
-				// only one notification
-				$data = [
-						'bot' => $bot,
-						'placeholders' => $placeholders,
-						'affectedUserIDs' => !$bot->testMode ? $affectedUserIDs : $testUserIDs,
-						'countToUserID' => !$bot->testMode ? $countToUserID : $testToUserIDs
-				];
-				
-				$job = new NotifyScheduleBackgroundJob($data);
-				BackgroundQueueHandler::getInstance()->performJob($job);
-			}
-			else {
-				$data = [
-						'bot' => $bot,
-						'placeholders' => $placeholders,
-						'affectedUserIDs' => !$bot->testMode ? $affectedUserIDs : $testUserIDs,
-						'countToUserID' => !$bot->testMode ? $countToUserID : $testToUserIDs
-				];
-				
-				$job = new NotifyScheduleBackgroundJob($data);
-				BackgroundQueueHandler::getInstance()->performJob($job);
-			}
-		}
-	}
+class UzbotLexiconModificationCronjob extends AbstractCronjob
+{
+    /**
+     * list with entries to be modified
+     */
+    protected $entryList;
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(Cronjob $cronjob)
+    {
+        parent::execute($cronjob);
+
+        if (!MODULE_UZBOT) {
+            return;
+        }
+
+        // Read all active, valid bots, abort if none
+        $bots = UzbotValidBotCacheBuilder::getInstance()->getData(['typeDes' => 'lexicon_modification']);
+        if (empty($bots)) {
+            return;
+        }
+
+        $defaultLanguage = LanguageFactory::getInstance()->getLanguage(LanguageFactory::getInstance()->getDefaultLanguageID());
+
+        // Step through all bots and get entries to be modified
+        foreach ($bots as $bot) {
+            // set data
+            $modifications = \unserialize($bot->lexiconModificationData);
+            $userData = [];
+
+            // check executer
+            $user = new User($modifications['lexiconModificationExecuterID']);
+            if (!$user->userID) {
+                $editor = new UzbotEditor($bot);
+                $editor->update(['isDisabled' => 1]);
+                UzbotEditor::resetCache();
+
+                if ($bot->enableLog) {
+                    UzbotLogEditor::create([
+                        'bot' => $bot,
+                        'count' => 0,
+                        'status' => 2,
+                        'additionalData' => $defaultLanguage->get('wcf.acp.uzbot.lexicon.error.executerInvalid'),
+                    ]);
+                }
+                continue;
+            }
+
+            // change user
+            $oldUser = WCF::getUser();
+            WCF::getSession()->changeUser(new User($modifications['lexiconModificationExecuterID']), true);
+
+            // get all entryIDs matching conditions
+            $conditions = ConditionHandler::getInstance()->getConditions('com.uz.wcf.bot.condition.lexicon', $bot->botID);
+            $conditionEntryIDs = [];
+            if (\count($conditions)) {
+                $entryList = new EntryList();
+                foreach ($conditions as $condition) {
+                    $condition->getObjectType()->getProcessor()->addObjectListCondition($entryList, $condition->conditionData);
+                }
+                $entryList->readObjectIDs();
+                $conditionEntryIDs = $entryList->getObjectIDs();
+                if (empty($conditionEntryIDs)) {
+                    $conditionEntryIDs[] = 0;
+                }
+            }
+            $conditionCount = \count($conditionEntryIDs);
+
+            // same for labels
+            $labelEntryIDs = [];
+            $useLabels = 0;
+            $labels = UzbotConditionLabelObjectHandler::getInstance()->getAssignedLabels([$bot->botID], false);
+            if (!empty($labels)) {
+                $useLabels = 1;
+                $labelIDs = [];
+                foreach ($labels as $temp) {
+                    foreach ($temp as $labelID => $label) {
+                        $labelIDs[] = $labelID;
+                    }
+                }
+
+                $objectType = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry');
+                $entryList = new EntryList();
+                foreach ($labelIDs as $labelID) {
+                    $entryList->getConditionBuilder()->add('entry.entryID IN (SELECT objectID FROM wcf' . WCF_N . '_label_object WHERE objectTypeID = ? AND labelID = ?)', [$objectType->objectTypeID, $labelID]);
+                }
+                $entryList->readObjectIDs();
+                $labelEntryIDs = $entryList->getObjectIDs();
+                if (empty($labelEntryIDs)) {
+                    $labelEntryIDs[] = 0;
+                }
+            }
+            $labelCount = \count($labelEntryIDs);
+
+            // category
+            $categoryEntryIDs = [];
+            if ($modifications['lexiconModificationCategoryID']) {
+                $entryList = new EntryList();
+                $entryList->getConditionBuilder()->add('entry.entryID IN (SELECT entryID FROM lexicon' . WCF_N . '_entry_to_category WHERE categoryID = ?)', [$modifications['lexiconModificationCategoryID']]);
+                $entryList->readObjectIDs();
+                $categoryEntryIDs = $entryList->getObjectIDs();
+                if (empty($categoryEntryIDs)) {
+                    $categoryEntryIDs[] = 0;
+                }
+            }
+            $categoryCount = \count($categoryEntryIDs);
+
+            // merge entryIDs
+            if (!$conditionCount && !$labelCount && !$categoryCount) {    // all entries
+                $entryList = new EntryList();
+                $entryList->readObjectIDs();
+                $entryIDs = $entryList->getObjectIDs();
+            } elseif ((isset($conditionEntryIDs[0]) && $conditionEntryIDs[0] == 0) || (isset($labelEntryIDs[0]) && $labelEntryIDs[0] == 0) || (isset($categoryEntryIDs[0]) && $categoryEntryIDs[0] == 0)) {
+                $entryIDs[0] = 0;
+            } else {
+                $tempArray[] = $conditionEntryIDs;
+                $tempArray[] = $labelEntryIDs;
+                $tempArray[] = $categoryEntryIDs;
+
+                $tempArray = \array_filter($tempArray);
+                $entryIDs = \array_shift($tempArray);
+                foreach ($tempArray as $array) {
+                    $entryIDs = \array_intersect($entryIDs, $array);
+                }
+            }
+
+            // if no entries, log and abort
+            $entryCount = \count($entryIDs);
+
+            // log found entries (not action)
+            if ($bot->enableLog) {
+                if ($entryCount == 1 && isset($entryIDs[0]) && $entryIDs[0] == 0) {
+                    $count = 0;
+                } else {
+                    $count = $entryCount;
+                }
+                $result = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.lexicon.entry.affected', ['count' => $count]);
+
+                if (!$bot->testMode) {
+                    UzbotLogEditor::create([
+                        'bot' => $bot,
+                        'count' => $count,
+                        'additionalData' => $result,
+                    ]);
+                } else {
+                    UzbotLogEditor::create([
+                        'bot' => $bot,
+                        'count' => $count,
+                        'testMode' => 1,
+                        'additionalData' => \serialize(['', '', $result]),
+                    ]);
+                }
+            }
+
+            // abort if no entries
+            if ($entryCount == 1 && isset($entryIDs[0]) && $entryIDs[0] == 0) {
+                // Reset to old user
+                WCF::getSession()->changeUser($oldUser, true);
+                continue;
+            }
+
+            // get actionLabelIDs and related data
+            $actionLabelIDs = [];
+            $actionLabels = UzbotActionLabelObjectHandler::getInstance()->getAssignedLabels([$bot->botID], false);
+            if (\count($actionLabels)) {
+                foreach ($actionLabels as $temp) {
+                    foreach ($temp as $label) {
+                        $actionLabelIDs[] = $label->labelID;
+                    }
+                }
+            }
+            $objectType = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry');
+            $labelObjectTypeID = $objectType->objectTypeID;
+
+            // step through entries until at least one entry was modified
+            $found = 0;
+            for ($i = 0; $i < $entryCount; $i += UZBOT_DATA_LIMIT_LEXICON) {
+                $ids = \array_slice($entryIDs, $i, UZBOT_DATA_LIMIT_LEXICON);
+
+                // step through action in sequence of add form
+                if ($modifications['lexiconModificationEnable']) {
+                    $entryList = new EntryList();
+                    $entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
+                    $entryList->getConditionBuilder()->add('entry.isDisabled = ?', [1]);
+                    $entryList->readObjects();
+                    $entries = $entryList->getObjects();
+                    if (\count($entries)) {
+                        $found = 1;
+                        $this->executeBot($bot, $entries, 'enable', $defaultLanguage);
+                    }
+                }
+
+                if ($modifications['lexiconModificationDisable']) {
+                    $entryList = new EntryList();
+                    $entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
+                    $entryList->getConditionBuilder()->add('entry.isDisabled = ?', [0]);
+                    $entryList->readObjects();
+                    $entries = $entryList->getObjects();
+                    if (\count($entries)) {
+                        $found = 1;
+                        $this->executeBot($bot, $entries, 'disable', $defaultLanguage);
+                    }
+                }
+
+                if ($modifications['lexiconModificationComplete']) {
+                    $entryList = new EntryList();
+                    $entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
+                    $entryList->getConditionBuilder()->add('entry.isCompleted = ?', [0]);
+                    $entryList->readObjects();
+                    $entries = $entryList->getObjects();
+                    if (\count($entries)) {
+                        $found = 1;
+                        $this->executeBot($bot, $entries, 'done', $defaultLanguage);
+                    }
+                }
+
+                if ($modifications['lexiconModificationUncomplete']) {
+                    $entryList = new EntryList();
+                    $entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
+                    $entryList->getConditionBuilder()->add('entry.isCompleted = ?', [1]);
+                    $entryList->readObjects();
+                    $entries = $entryList->getObjects();
+                    if (\count($entries)) {
+                        $found = 1;
+                        $this->executeBot($bot, $entries, 'undone', $defaultLanguage);
+                    }
+                }
+
+                if ($modifications['lexiconModificationSetLabel']) {
+                    // user wants to delete labels
+                    if (!\count($actionLabelIDs)) {
+                        $entryList = new EntryList();
+                        $entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$ids]);
+                        $entryList->getConditionBuilder()->add('entry.hasLabels = ?', [1]);
+                        $entryList->readObjects();
+                        $entries = $entryList->getObjects();
+                        if (\count($entries)) {
+                            $found = 1;
+                            $this->executeBot($bot, $entries, 'deleteLabels', $defaultLanguage);
+                        }
+                    }
+
+                    // user wants to add / change labels
+                    else {
+                        // read actual label assignment and get entries to be modified
+                        $assign = $modifyID = [];
+                        $conditionBuilder = new PreparedStatementConditionBuilder();
+                        $conditionBuilder->add('objectTypeID = ?', [$labelObjectTypeID]);
+                        $conditionBuilder->add('objectID IN (?)', [$ids]);
+                        $sql = "SELECT     objectID, labelID
+                                FROM    wcf" . WCF_N . "_label_object
+                                " . $conditionBuilder;
+                        $statement = WCF::getDB()->prepareStatement($sql);
+                        $statement->execute($conditionBuilder->getParameters());
+                        while ($row = $statement->fetchArray()) {
+                            $assign[$row['objectID']][] = $row['labelID'];
+                        }
+
+                        $modifyID = [];
+                        foreach ($ids as $entryID) {
+                            if (!isset($assign[$entryID])) {
+                                $modifyID[] = $entryID;
+                                continue;
+                            }
+                            if (\count($assign[$entryID]) != \count($actionLabelIDs)) {
+                                $modifyID[] = $entryID;
+                                continue;
+                            }
+                            if (!empty(\array_diff($actionLabelIDs, $assign[$entryID]))) {
+                                $modifyID[] = $entryID;
+                            }
+                        }
+
+                        if (\count($modifyID)) {
+                            $entryList = new EntryList();
+                            $entryList->getConditionBuilder()->add('entry.entryID IN (?)', [$modifyID]);
+                            $entryList->readObjects();
+                            $entries = $entryList->getObjects();
+                            if (\count($entries)) {
+                                $found = 1;
+                                $this->executeBot($bot, $entries, 'setLabels', $defaultLanguage, $actionLabels);
+                            }
+                        }
+                    }
+                }
+
+                // break if entry was found
+                if ($found) {
+                    break;
+                }
+            }
+
+            // Reset to old user
+            WCF::getSession()->changeUser($oldUser, true);
+        }
+    }
+
+    protected function executeBot($bot, $entries, $action, $defaultLanguage, $labels = [])
+    {
+        $affectedUserIDs = $countToUserID = $placeholders = $entryIDs = $entryToUser = [];
+
+        if (!\count($entries)) {
+            if ($bot->enableLog) {
+                if (!$bot->testMode) {
+                    UzbotLogEditor::create([
+                        'bot' => $bot,
+                        'count' => 0,
+                        'additionalData' => $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.lexicon.entry.modified', [
+                            'action' => $defaultLanguage->get('wcf.acp.uzbot.lexicon.entryModification.action.' . $action),
+                            'entryIDs' => '',
+                        ]),
+                    ]);
+
+                    UzbotLogEditor::create([
+                        'bot' => $bot,
+                        'count' => \count($affectedUserIDs),
+                        'additionalData' => $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.user.affected', [
+                            'total' => 0,
+                            'userIDs' => '',
+                        ]),
+                    ]);
+                } else {
+                    $result = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.test', [
+                        'objects' => 0,
+                        'users' => 0,
+                        'userIDs' => '',
+                    ]);
+                    if (\mb_strlen($result) > 64000) {
+                        $result = \mb_substr($result, 0, 64000) . ' ...';
+                    }
+                    UzbotLogEditor::create([
+                        'bot' => $bot,
+                        'count' => \count($entryIDs),
+                        'testMode' => 1,
+                        'additionalData' => \serialize(['', '', $result]),
+                    ]);
+                }
+            }
+
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            $entryIDs[] = $entry->entryID;
+
+            if (!$entry->userID) {
+                continue;
+            }
+
+            $entryToUser[$entry->entryID] = $entry->userID;
+
+            $affectedUserIDs[] = $entry->userID;
+            if (isset($countToUserID[$entry->userID])) {
+                $countToUserID[$entry->userID]++;
+            } else {
+                $countToUserID[$entry->userID] = 1;
+            }
+        }
+
+        $affectedUserIDs = \array_unique($affectedUserIDs);
+
+        // change user for action + execute unless test mode
+        if (!$bot->testMode) {
+            if ($action != 'setLabels' && $action != 'deleteLabels') {
+                $entryAction = new EntryAction($entries, $action);
+                $entryAction->executeAction();
+            } else {
+                // label object type
+                $objectType = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry');
+                $objectTypeID = $objectType->objectTypeID;
+
+                // delete ...
+                if ($action == 'deleteLabels') {
+                    $objectTypeID = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry')->objectTypeID;
+                    $oldLabels = LabelHandler::getInstance()->getAssignedLabels($objectTypeID, $entryIDs);
+
+                    // remove labels
+                    foreach ($entries as $entry) {
+                        LabelHandler::getInstance()->setLabels([], $objectTypeID, $entry->entryID);
+
+                        // update hasLabels flag
+                        $editor = new EntryEditor($entry);
+                        $editor->update(['hasLabels' => 0]);
+                    }
+                }
+
+                // set ...
+                if ($action == 'setLabels') {
+                    foreach ($labels as $temp) {
+                        foreach ($temp as $label) {
+                            $labelIDs[] = $label->labelID;
+                        }
+                    }
+                    $botLabels = $labels;
+                    $botLabelIDs = $labelIDs;
+
+                    // almost same as above
+                    $objectTypeID = LabelHandler::getInstance()->getObjectType('com.viecode.lexicon.entry')->objectTypeID;
+                    $oldLabels = LabelHandler::getInstance()->getAssignedLabels($objectTypeID, $entryIDs);
+
+                    foreach ($entries as $entry) {
+                        LabelHandler::getInstance()->setLabels($botLabelIDs, $objectTypeID, $entry->entryID);
+
+                        $editor = new EntryEditor($entry);
+                        $editor->update(['hasLabels' => !empty($botLabelIDs) ? 1 : 0]);
+                    }
+                }
+            }
+        }
+
+        if ($bot->enableLog) {
+            $result1 = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.lexicon.entry.modified', [
+                'action' => $defaultLanguage->get('wcf.acp.uzbot.lexicon.entryModification.action.' . $action),
+                'entryIDs' => \implode(', ', $entryIDs),
+            ]);
+            if (\mb_strlen($result1) > 64000) {
+                $result1 = \mb_substr($result1, 0, 64000) . ' ...';
+            }
+
+            $result2 = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.user.affected', [
+                'total' => \count($affectedUserIDs),
+                'userIDs' => \implode(', ', $affectedUserIDs),
+            ]);
+            if (\mb_strlen($result2) > 64000) {
+                $result2 = \mb_substr($result2, 0, 64000) . ' ...';
+            }
+
+            UzbotLogEditor::create([
+                'bot' => $bot,
+                'testMode' => !$bot->testMode ? 0 : 1,
+                'count' => \count($entryIDs),
+                'additionalData' => !$bot->testMode ? $result1 : \serialize(['', '', $result1]),
+            ]);
+
+            UzbotLogEditor::create([
+                'bot' => $bot,
+                'testMode' => !$bot->testMode ? 0 : 1,
+                'count' => \count($affectedUserIDs),
+                'additionalData' => !$bot->testMode ? $result2 : \serialize(['', '', $result2]),
+            ]);
+        }
+
+        // check for and prepare notification
+        if ($bot->notifyID) {
+            $notify = $bot->checkNotify(true, true);
+            if ($notify === null) {
+                return;
+            }
+
+            $placeholders['count'] = \count($entryIDs);
+            $placeholders['object-ids'] = \implode(', ', $entryIDs);
+            $placeholders['action'] = $defaultLanguage->get('wcf.acp.uzbot.lexicon.entryModification.action.' . $action);
+
+            // test mode
+            $testUserIDs = $testToUserIDs = [];
+            if (\count($affectedUserIDs)) {
+                $userID = \reset($affectedUserIDs);
+                $testUserIDs[] = $userID;
+                $testToUserIDs[$userID] = $countToUserID[$userID];
+            }
+
+            // send to scheduler, if not test mode
+            if ($bot->testMode) {
+                // only one notification
+                $data = [
+                    'bot' => $bot,
+                    'placeholders' => $placeholders,
+                    'affectedUserIDs' => !$bot->testMode ? $affectedUserIDs : $testUserIDs,
+                    'countToUserID' => !$bot->testMode ? $countToUserID : $testToUserIDs,
+                ];
+
+                $job = new NotifyScheduleBackgroundJob($data);
+                BackgroundQueueHandler::getInstance()->performJob($job);
+            } else {
+                $data = [
+                    'bot' => $bot,
+                    'placeholders' => $placeholders,
+                    'affectedUserIDs' => !$bot->testMode ? $affectedUserIDs : $testUserIDs,
+                    'countToUserID' => !$bot->testMode ? $countToUserID : $testToUserIDs,
+                ];
+
+                $job = new NotifyScheduleBackgroundJob($data);
+                BackgroundQueueHandler::getInstance()->performJob($job);
+            }
+        }
+    }
 }

--- a/files/lib/system/event/listener/UzbotAddFormLexiconListener.class.php
+++ b/files/lib/system/event/listener/UzbotAddFormLexiconListener.class.php
@@ -1,5 +1,27 @@
 <?php
+
+/*
+ * Copyright by Udo Zaydowicz.
+ * Modified by SoftCreatR.dev.
+ *
+ * License: http://opensource.org/licenses/lgpl-license.php
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 namespace lexicon\system\event\listener;
+
 use lexicon\data\category\LexiconCategoryNodeTree;
 use lexicon\system\condition\uzbot\UzbotLexiconConditionHandler;
 use wcf\data\user\User;
@@ -13,248 +35,295 @@ use wcf\util\ArrayUtil;
 use wcf\util\StringUtil;
 
 /**
- * Listen to addForm events for Bot 
- * 
- * @author		2019-2022 Zaydowicz
- * @license		GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package		com.uz.wcf.bot3.lexicon
+ * Listen to addForm events for Bot
  */
 
-class UzbotAddFormLexiconListener implements IParameterizedEventListener {
-	/**
-	 * instance of UzbotAddForm
-	 */
-	protected $eventObj;
-	
-	/**
-	 * lexicon data
-	 */
-	protected $lexiconModificationData = 0;
-	protected $lexiconModificationExecuter = '';
-	protected $lexiconModificationExecuterID = 0;
-	protected $lexiconModificationCategoryID = 0;
-	protected $lexiconModificationDisable = 0;
-	protected $lexiconModificationEnable = 0;
-	protected $lexiconModificationComplete = 0;
-	protected $lexiconModificationUncomplete = 0;
-	protected $lexiconModificationSetLabel = 0;
-	protected $lexiconModificationTrash = 0;
-	
-	/**
-	 * further bot data
-	 */
-	protected $lexiconCountAction = 'entryTotal';
-	protected $topLexiconCount = 1;
-	protected $topLexiconInterval = 1;
-	protected $lexiconChangeUpdate = 1;
-	protected $lexiconChangeDelete = 1;
-	
-	/**
-	 * condition data
-	 */
-	public $lexiconConditions = [];
-	
-	/**
-	 * @inheritDoc
-	 */
-	public function execute($eventObj, $className, $eventName, array &$parameters) {
-		$this->eventObj = $eventObj;
-		$this->$eventName();
-	}
-	
-	/**
-	 * Handles the readData event. Only in UzbotEdit!
-	 */
-	protected function readData() {
-		
-		if (empty($_POST)) {
-			if (!empty($this->eventObj->uzbot->lexiconModificationData)) {
-				$lexiconModificationData = unserialize($this->eventObj->uzbot->lexiconModificationData);
-				$this->lexiconModificationExecuter = $lexiconModificationData['lexiconModificationExecuter'];
-				$this->lexiconModificationExecuterID = $lexiconModificationData['lexiconModificationExecuterID'];
-				$this->lexiconModificationCategoryID = $lexiconModificationData['lexiconModificationCategoryID'];
-				$this->lexiconModificationDisable = $lexiconModificationData['lexiconModificationDisable'];
-				$this->lexiconModificationEnable = $lexiconModificationData['lexiconModificationEnable'];
-				$this->lexiconModificationComplete = $lexiconModificationData['lexiconModificationComplete'];
-				$this->lexiconModificationUncomplete = $lexiconModificationData['lexiconModificationUncomplete'];
-				$this->lexiconModificationSetLabel = $lexiconModificationData['lexiconModificationSetLabel'];
-			}
-			
-			$this->lexiconCountAction = $this->eventObj->uzbot->lexiconCountAction;
-			$this->topLexiconCount = $this->eventObj->uzbot->topLexiconCount;
-			$this->topLexiconInterval = $this->eventObj->uzbot->topLexiconInterval;
-			$this->lexiconChangeUpdate = $this->eventObj->uzbot->lexiconChangeUpdate;
-			$this->lexiconChangeDelete = $this->eventObj->uzbot->lexiconChangeDelete;
-			
-			// conditions
-			$this->lexiconConditions = UzbotLexiconConditionHandler::getInstance()->getGroupedObjectTypes();
-			$conditions = ConditionHandler::getInstance()->getConditions('com.uz.wcf.bot.condition.lexicon', $this->eventObj->botID);
-			
-			foreach ($conditions as $condition) {
-				$this->lexiconConditions[$condition->getObjectType()->conditiongroup][$condition->objectTypeID]->getProcessor()->setData($condition);
-			}
-		}
-	}
-	
-	/**
-	 * Handles the assignVariables event.
-	 */
-	protected function assignVariables() {
-		$this->lexiconConditions = UzbotLexiconConditionHandler::getInstance()->getGroupedObjectTypes();
-		
-		$categoryTree = new LexiconCategoryNodeTree('com.viecode.lexicon.category');
-		$categoryNodeList= $categoryTree->getIterator();
-		
-		WCF::getTPL()->assign([
-				'lexiconCountAction' => $this->lexiconCountAction,
-				'topLexiconCount' => $this->topLexiconCount,
-				'topLexiconInterval' => $this->topLexiconInterval,
-				'lexiconChangeUpdate' => $this->lexiconChangeUpdate,
-				'lexiconChangeDelete' => $this->lexiconChangeDelete,
-				
-				'lexiconCategoryNodeList' => $categoryNodeList,
-				
-				'lexiconModificationExecuter' => $this->lexiconModificationExecuter,
-				'lexiconModificationExecuterID' => $this->lexiconModificationExecuterID,
-				'lexiconModificationCategoryID' => $this->lexiconModificationCategoryID,
-				'lexiconModificationDisable' => $this->lexiconModificationDisable,
-				'lexiconModificationEnable' => $this->lexiconModificationEnable,
-				'lexiconModificationComplete' => $this->lexiconModificationComplete,
-				'lexiconModificationUncomplete' => $this->lexiconModificationUncomplete,
-				'lexiconModificationSetLabel' => $this->lexiconModificationSetLabel,
-				
-				'lexiconConditions' => $this->lexiconConditions
-		]);
-	}
-	
-	/**
-	 * Handles the readFormParameters event.
-	 */
-	protected function readFormParameters() {
-		if (isset($_POST['lexiconCountAction'])) $this->lexiconCountAction = StringUtil::trim($_POST['lexiconCountAction']);
-		if (isset($_POST['topLexiconCount'])) $this->topLexiconCount = intval($_POST['topLexiconCount']);
-		if (isset($_POST['topLexiconInterval'])) $this->topLexiconInterval = intval($_POST['topLexiconInterval']);
-		$this->lexiconChangeUpdate = $this->lexiconChangeDelete = 0;
-		if (isset($_POST['lexiconChangeUpdate'])) $this->lexiconChangeUpdate = intval($_POST['lexiconChangeUpdate']);
-		if (isset($_POST['lexiconChangeDelete'])) $this->lexiconChangeDelete = intval($_POST['lexiconChangeDelete']);
-		
-		$this->lexiconModificationDisable = 0;
-		$this->lexiconModificationEnable = $this->lexiconModificationComplete = 0;
-		$this->lexiconModificationUncomplete = $this->lexiconModificationSetLabel = 0;
-		if (isset($_POST['lexiconModificationExecuter'])) $this->lexiconModificationExecuter = StringUtil::trim($_POST['lexiconModificationExecuter']);
-		if (isset($_POST['lexiconModificationExecuterID'])) $this->lexiconModificationExecuterID = intval($_POST['lexiconModificationExecuterID']);
-		if (isset($_POST['lexiconModificationCategoryID'])) $this->lexiconModificationCategoryID = intval($_POST['lexiconModificationCategoryID']);
-		if (isset($_POST['lexiconModificationDisable'])) $this->lexiconModificationDisable = intval($_POST['lexiconModificationDisable']);
-		if (isset($_POST['lexiconModificationEnable'])) $this->lexiconModificationEnable = intval($_POST['lexiconModificationEnable']);
-		if (isset($_POST['lexiconModificationComplete'])) $this->lexiconModificationComplete = intval($_POST['lexiconModificationComplete']);
-		if (isset($_POST['lexiconModificationUncomplete'])) $this->lexiconModificationUncomplete = intval($_POST['lexiconModificationUncomplete']);
-		if (isset($_POST['lexiconModificationSetLabel'])) $this->lexiconModificationSetLabel = intval($_POST['lexiconModificationSetLabel']);
-		
-		$this->lexiconModificationData = [
-				'lexiconModificationExecuter' => $this->lexiconModificationExecuter,
-				'lexiconModificationExecuterID' => $this->lexiconModificationExecuterID,
-				'lexiconModificationCategoryID' => $this->lexiconModificationCategoryID,
-				'lexiconModificationDisable' => $this->lexiconModificationDisable,
-				'lexiconModificationEnable' => $this->lexiconModificationEnable,
-				'lexiconModificationComplete' => $this->lexiconModificationComplete,
-				'lexiconModificationUncomplete' => $this->lexiconModificationUncomplete,
-				'lexiconModificationSetLabel' => $this->lexiconModificationSetLabel,
-		];
-		
-		// read conditions
-		$this->lexiconConditions = UzbotLexiconConditionHandler::getInstance()->getGroupedObjectTypes();
-		foreach ($this->lexiconConditions as $conditions) {
-			foreach ($conditions as $condition) {
-				$condition->getProcessor()->readFormParameters();
-			}
-		}
-	}
-	
-	/**
-	 * Handles the validate event.
-	 */
-	protected function validate() {
-		
-		// Get type / notify data
-		$type = UzbotType::getTypeByID($this->eventObj->typeID);
-		$notify = UzbotNotify::getNotifyByID($this->eventObj->notifyID);
-		
-		// need notify?
-		if ($type->needNotify && !$notify->notifyID) {
-			throw new UserInputException('notifyID', 'missing');
-		}
-		
-		// need count for trigger values
-		if ($type->needCount && $type->typeTitle == 'lexicon_count') {
-			if ($this->lexiconCountAction == 'entryTotal' || $this->lexiconCountAction == 'entryX') {
-				$counts = ArrayUtil::trim(explode(',', $this->eventObj->userCount));
-				$counts = ArrayUtil::toIntegerArray($counts);
-				
-				if (!count($counts)) throw new UserInputException('userCount', 'empty');
-			}
-		}
-		
-		// lexicon_change
-		if ($type->typeTitle == 'lexicon_change') {
-			if (!$this->lexiconChangeUpdate && !$this->lexiconChangeDelete) {
-				throw new UserInputException('lexiconChangeAction', 'notConfigured');
-			}
-		}
-		
-		// entry modification
-		if ($type->typeTitle == 'lexicon_modification') {
-			// unset change labels if no labels
-			if (empty($this->eventObj->labelGroups) || empty($this->eventObj->availableLabels)) {
-				$this->lexiconModificationData['lexiconModificationSetLabel'] = 0;
-				$this->lexiconModificationSetLabel = 0;
-			}
-			
-			if (array_sum($this->lexiconModificationData) == 0) {
-				throw new UserInputException('lexiconModificationAction', 'notConfigured');
-			}
-			
-			// executer must exist
-			if (empty($this->lexiconModificationExecuter)) throw new UserInputException('lexiconModificationExecuter');
-			$user = User::getUserByUsername($this->lexiconModificationExecuter);
-			if (!$user->userID) throw new UserInputException('lexiconModificationExecuter', 'invalid');
-			$this->lexiconModificationExecuterID = $user->userID;
-			$this->lexiconModificationData['lexiconModificationExecuterID'] = $user->userID;
-			
-			// conditions
-			foreach ($this->lexiconConditions as $conditions) {
-				foreach ($conditions as $condition) {
-					$condition->getProcessor()->validate();
-				}
-			}
-		}
-	}
-	
-	/**
-	 * Handles the save event.
-	 */
-	protected function save() {
-		$this->eventObj->additionalFields = array_merge($this->eventObj->additionalFields, [
-				'lexiconModificationData' => serialize($this->lexiconModificationData),
-				'lexiconCountAction' => $this->lexiconCountAction,
-				'topLexiconCount' => $this->topLexiconCount,
-				'topLexiconInterval' => $this->topLexiconInterval,
-				'topLexiconNext' => 0,
-				'lexiconChangeUpdate' => $this->lexiconChangeUpdate,
-				'lexiconChangeDelete' => $this->lexiconChangeDelete
-		]);
-	}
-	
-	/**
-	 * Handles the saved event.
-	 */
-	protected function saved() {
-		// transform conditions array into one-dimensional array and save
-		$conditions = [];
-		foreach ($this->lexiconConditions as $groupedObjectTypes) {
-			$conditions = array_merge($conditions, $groupedObjectTypes);
-		}
-		
-		$oldConditions = ConditionHandler::getInstance()->getConditions('com.uz.wcf.bot.condition.lexicon', $this->eventObj->botID);
-		ConditionHandler::getInstance()->updateConditions($this->eventObj->botID, $oldConditions, $conditions);
-	}
+class UzbotAddFormLexiconListener implements IParameterizedEventListener
+{
+    /**
+     * instance of UzbotAddForm
+     */
+    protected $eventObj;
+
+    /**
+     * lexicon data
+     */
+    protected $lexiconModificationData = 0;
+
+    protected $lexiconModificationExecuter = '';
+
+    protected $lexiconModificationExecuterID = 0;
+
+    protected $lexiconModificationCategoryID = 0;
+
+    protected $lexiconModificationDisable = 0;
+
+    protected $lexiconModificationEnable = 0;
+
+    protected $lexiconModificationComplete = 0;
+
+    protected $lexiconModificationUncomplete = 0;
+
+    protected $lexiconModificationSetLabel = 0;
+
+    protected $lexiconModificationTrash = 0;
+
+    /**
+     * further bot data
+     */
+    protected $lexiconCountAction = 'entryTotal';
+
+    protected $topLexiconCount = 1;
+
+    protected $topLexiconInterval = 1;
+
+    protected $lexiconChangeUpdate = 1;
+
+    protected $lexiconChangeDelete = 1;
+
+    /**
+     * condition data
+     */
+    public $lexiconConditions = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function execute($eventObj, $className, $eventName, array &$parameters)
+    {
+        $this->eventObj = $eventObj;
+        $this->{$eventName}();
+    }
+
+    /**
+     * Handles the readData event. Only in UzbotEdit!
+     */
+    protected function readData()
+    {
+        if (empty($_POST)) {
+            if (!empty($this->eventObj->uzbot->lexiconModificationData)) {
+                $lexiconModificationData = \unserialize($this->eventObj->uzbot->lexiconModificationData);
+                $this->lexiconModificationExecuter = $lexiconModificationData['lexiconModificationExecuter'];
+                $this->lexiconModificationExecuterID = $lexiconModificationData['lexiconModificationExecuterID'];
+                $this->lexiconModificationCategoryID = $lexiconModificationData['lexiconModificationCategoryID'];
+                $this->lexiconModificationDisable = $lexiconModificationData['lexiconModificationDisable'];
+                $this->lexiconModificationEnable = $lexiconModificationData['lexiconModificationEnable'];
+                $this->lexiconModificationComplete = $lexiconModificationData['lexiconModificationComplete'];
+                $this->lexiconModificationUncomplete = $lexiconModificationData['lexiconModificationUncomplete'];
+                $this->lexiconModificationSetLabel = $lexiconModificationData['lexiconModificationSetLabel'];
+            }
+
+            $this->lexiconCountAction = $this->eventObj->uzbot->lexiconCountAction;
+            $this->topLexiconCount = $this->eventObj->uzbot->topLexiconCount;
+            $this->topLexiconInterval = $this->eventObj->uzbot->topLexiconInterval;
+            $this->lexiconChangeUpdate = $this->eventObj->uzbot->lexiconChangeUpdate;
+            $this->lexiconChangeDelete = $this->eventObj->uzbot->lexiconChangeDelete;
+
+            // conditions
+            $this->lexiconConditions = UzbotLexiconConditionHandler::getInstance()->getGroupedObjectTypes();
+            $conditions = ConditionHandler::getInstance()->getConditions('com.uz.wcf.bot.condition.lexicon', $this->eventObj->botID);
+
+            foreach ($conditions as $condition) {
+                $this->lexiconConditions[$condition->getObjectType()->conditiongroup][$condition->objectTypeID]->getProcessor()->setData($condition);
+            }
+        }
+    }
+
+    /**
+     * Handles the assignVariables event.
+     */
+    protected function assignVariables()
+    {
+        $this->lexiconConditions = UzbotLexiconConditionHandler::getInstance()->getGroupedObjectTypes();
+
+        $categoryTree = new LexiconCategoryNodeTree('com.viecode.lexicon.category');
+        $categoryNodeList = $categoryTree->getIterator();
+
+        WCF::getTPL()->assign([
+            'lexiconCountAction' => $this->lexiconCountAction,
+            'topLexiconCount' => $this->topLexiconCount,
+            'topLexiconInterval' => $this->topLexiconInterval,
+            'lexiconChangeUpdate' => $this->lexiconChangeUpdate,
+            'lexiconChangeDelete' => $this->lexiconChangeDelete,
+
+            'lexiconCategoryNodeList' => $categoryNodeList,
+
+            'lexiconModificationExecuter' => $this->lexiconModificationExecuter,
+            'lexiconModificationExecuterID' => $this->lexiconModificationExecuterID,
+            'lexiconModificationCategoryID' => $this->lexiconModificationCategoryID,
+            'lexiconModificationDisable' => $this->lexiconModificationDisable,
+            'lexiconModificationEnable' => $this->lexiconModificationEnable,
+            'lexiconModificationComplete' => $this->lexiconModificationComplete,
+            'lexiconModificationUncomplete' => $this->lexiconModificationUncomplete,
+            'lexiconModificationSetLabel' => $this->lexiconModificationSetLabel,
+
+            'lexiconConditions' => $this->lexiconConditions,
+        ]);
+    }
+
+    /**
+     * Handles the readFormParameters event.
+     */
+    protected function readFormParameters()
+    {
+        if (isset($_POST['lexiconCountAction'])) {
+            $this->lexiconCountAction = StringUtil::trim($_POST['lexiconCountAction']);
+        }
+        if (isset($_POST['topLexiconCount'])) {
+            $this->topLexiconCount = \intval($_POST['topLexiconCount']);
+        }
+        if (isset($_POST['topLexiconInterval'])) {
+            $this->topLexiconInterval = \intval($_POST['topLexiconInterval']);
+        }
+        $this->lexiconChangeUpdate = $this->lexiconChangeDelete = 0;
+        if (isset($_POST['lexiconChangeUpdate'])) {
+            $this->lexiconChangeUpdate = \intval($_POST['lexiconChangeUpdate']);
+        }
+        if (isset($_POST['lexiconChangeDelete'])) {
+            $this->lexiconChangeDelete = \intval($_POST['lexiconChangeDelete']);
+        }
+
+        $this->lexiconModificationDisable = 0;
+        $this->lexiconModificationEnable = $this->lexiconModificationComplete = 0;
+        $this->lexiconModificationUncomplete = $this->lexiconModificationSetLabel = 0;
+        if (isset($_POST['lexiconModificationExecuter'])) {
+            $this->lexiconModificationExecuter = StringUtil::trim($_POST['lexiconModificationExecuter']);
+        }
+        if (isset($_POST['lexiconModificationExecuterID'])) {
+            $this->lexiconModificationExecuterID = \intval($_POST['lexiconModificationExecuterID']);
+        }
+        if (isset($_POST['lexiconModificationCategoryID'])) {
+            $this->lexiconModificationCategoryID = \intval($_POST['lexiconModificationCategoryID']);
+        }
+        if (isset($_POST['lexiconModificationDisable'])) {
+            $this->lexiconModificationDisable = \intval($_POST['lexiconModificationDisable']);
+        }
+        if (isset($_POST['lexiconModificationEnable'])) {
+            $this->lexiconModificationEnable = \intval($_POST['lexiconModificationEnable']);
+        }
+        if (isset($_POST['lexiconModificationComplete'])) {
+            $this->lexiconModificationComplete = \intval($_POST['lexiconModificationComplete']);
+        }
+        if (isset($_POST['lexiconModificationUncomplete'])) {
+            $this->lexiconModificationUncomplete = \intval($_POST['lexiconModificationUncomplete']);
+        }
+        if (isset($_POST['lexiconModificationSetLabel'])) {
+            $this->lexiconModificationSetLabel = \intval($_POST['lexiconModificationSetLabel']);
+        }
+
+        $this->lexiconModificationData = [
+            'lexiconModificationExecuter' => $this->lexiconModificationExecuter,
+            'lexiconModificationExecuterID' => $this->lexiconModificationExecuterID,
+            'lexiconModificationCategoryID' => $this->lexiconModificationCategoryID,
+            'lexiconModificationDisable' => $this->lexiconModificationDisable,
+            'lexiconModificationEnable' => $this->lexiconModificationEnable,
+            'lexiconModificationComplete' => $this->lexiconModificationComplete,
+            'lexiconModificationUncomplete' => $this->lexiconModificationUncomplete,
+            'lexiconModificationSetLabel' => $this->lexiconModificationSetLabel,
+        ];
+
+        // read conditions
+        $this->lexiconConditions = UzbotLexiconConditionHandler::getInstance()->getGroupedObjectTypes();
+        foreach ($this->lexiconConditions as $conditions) {
+            foreach ($conditions as $condition) {
+                $condition->getProcessor()->readFormParameters();
+            }
+        }
+    }
+
+    /**
+     * Handles the validate event.
+     */
+    protected function validate()
+    {
+        // Get type / notify data
+        $type = UzbotType::getTypeByID($this->eventObj->typeID);
+        $notify = UzbotNotify::getNotifyByID($this->eventObj->notifyID);
+
+        // need notify?
+        if ($type->needNotify && !$notify->notifyID) {
+            throw new UserInputException('notifyID', 'missing');
+        }
+
+        // need count for trigger values
+        if ($type->needCount && $type->typeTitle == 'lexicon_count') {
+            if ($this->lexiconCountAction == 'entryTotal' || $this->lexiconCountAction == 'entryX') {
+                $counts = ArrayUtil::trim(\explode(',', $this->eventObj->userCount));
+                $counts = ArrayUtil::toIntegerArray($counts);
+
+                if (!\count($counts)) {
+                    throw new UserInputException('userCount', 'empty');
+                }
+            }
+        }
+
+        // lexicon_change
+        if ($type->typeTitle == 'lexicon_change') {
+            if (!$this->lexiconChangeUpdate && !$this->lexiconChangeDelete) {
+                throw new UserInputException('lexiconChangeAction', 'notConfigured');
+            }
+        }
+
+        // entry modification
+        if ($type->typeTitle == 'lexicon_modification') {
+            // unset change labels if no labels
+            if (empty($this->eventObj->labelGroups) || empty($this->eventObj->availableLabels)) {
+                $this->lexiconModificationData['lexiconModificationSetLabel'] = 0;
+                $this->lexiconModificationSetLabel = 0;
+            }
+
+            if (\array_sum($this->lexiconModificationData) == 0) {
+                throw new UserInputException('lexiconModificationAction', 'notConfigured');
+            }
+
+            // executer must exist
+            if (empty($this->lexiconModificationExecuter)) {
+                throw new UserInputException('lexiconModificationExecuter');
+            }
+            $user = User::getUserByUsername($this->lexiconModificationExecuter);
+            if (!$user->userID) {
+                throw new UserInputException('lexiconModificationExecuter', 'invalid');
+            }
+            $this->lexiconModificationExecuterID = $user->userID;
+            $this->lexiconModificationData['lexiconModificationExecuterID'] = $user->userID;
+
+            // conditions
+            foreach ($this->lexiconConditions as $conditions) {
+                foreach ($conditions as $condition) {
+                    $condition->getProcessor()->validate();
+                }
+            }
+        }
+    }
+
+    /**
+     * Handles the save event.
+     */
+    protected function save()
+    {
+        $this->eventObj->additionalFields = \array_merge($this->eventObj->additionalFields, [
+            'lexiconModificationData' => \serialize($this->lexiconModificationData),
+            'lexiconCountAction' => $this->lexiconCountAction,
+            'topLexiconCount' => $this->topLexiconCount,
+            'topLexiconInterval' => $this->topLexiconInterval,
+            'topLexiconNext' => 0,
+            'lexiconChangeUpdate' => $this->lexiconChangeUpdate,
+            'lexiconChangeDelete' => $this->lexiconChangeDelete,
+        ]);
+    }
+
+    /**
+     * Handles the saved event.
+     */
+    protected function saved()
+    {
+        // transform conditions array into one-dimensional array and save
+        $conditions = [];
+        foreach ($this->lexiconConditions as $groupedObjectTypes) {
+            $conditions = \array_merge($conditions, $groupedObjectTypes);
+        }
+
+        $oldConditions = ConditionHandler::getInstance()->getConditions('com.uz.wcf.bot.condition.lexicon', $this->eventObj->botID);
+        ConditionHandler::getInstance()->updateConditions($this->eventObj->botID, $oldConditions, $conditions);
+    }
 }

--- a/files/lib/system/event/listener/UzbotLexiconActionListener.class.php
+++ b/files/lib/system/event/listener/UzbotLexiconActionListener.class.php
@@ -1,5 +1,27 @@
 <?php
+
+/*
+ * Copyright by Udo Zaydowicz.
+ * Modified by SoftCreatR.dev.
+ *
+ * License: http://opensource.org/licenses/lgpl-license.php
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 namespace lexicon\system\event\listener;
+
 use wcf\data\user\User;
 use wcf\data\user\UserList;
 use wcf\data\uzbot\log\UzbotLogEditor;
@@ -12,241 +34,255 @@ use wcf\system\WCF;
 
 /**
  * Listen to entry actions for Bot
- *  
- * @author		2019-2022 Zaydowicz
- * @license		GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package		com.uz.wcf.bot3.lexicon
  */
-class UzbotLexiconActionListener implements IParameterizedEventListener {
-	/**
-	 * @inheritDoc
-	 */
-	public function execute($eventObj, $className, $eventName, array &$parameters) {
-		// check module
-		if (!MODULE_UZBOT) return;
-		
-		$action = $eventObj->getActionName();
-		$defaultLanguage = LanguageFactory::getInstance()->getLanguage(LanguageFactory::getInstance()->getDefaultLanguageID());
-		
-		// entry publication
-		if ($action == 'triggerPublication') {
-			// Read all active, valid bots, abort if none
-			$bots = UzbotValidBotCacheBuilder::getInstance()->getData(['typeDes' => 'lexicon_new']);
-			if (!count($bots)) {
-				return;
-			}
-			
-			// get entries
-			$entries = $eventObj->getObjects();
-			if (!count($entries)) return;
-			
-			foreach ($entries as $editor) {
-				$entry = $editor->getDecoratedObject();
-				
-				foreach ($bots as $bot) {
-					$affectedUserIDs = $countToUserID = $placeholders = [];
-					$count = 1;
-					
-					// check for conditions, if exist, no guests
-					$conditions = $bot->getUserConditions();
-					if (count($conditions)) {
-						if (!$entry->userID) {
-							continue;
-						}
-						else {
-							$userList = new UserList();
-							$userList->getConditionBuilder()->add('user_table.userID = ?', [$entry->userID]);
-							foreach ($conditions as $condition) {
-								$condition->getObjectType()->getProcessor()->addUserCondition($condition, $userList);
-							}
-							$userList->readObjects();
-							if (!count($userList->getObjects())) {
-								continue;
-							}
-						}
-					}
-					
-					// affected user
-					$user = null;
-					if ($entry->userID) {
-						$user = new User($entry->userID);
-						if (!$user->userID) {
-							$user = null;
-						}
-					}
-					
-					if ($user) {
-						$affectedUserIDs[] = $user->userID;
-						$countToUserID[$user->userID] = 1;
-					}
-					else {
-						$placeholders['user-email'] = $placeholders['user-groups'] = 'wcf.user.guest';
-						$placeholders['user-name'] = $placeholders['user-profile'] = $placeholders['@user-profile'] = 'wcf.user.guest';
-						$placeholders['user-age'] = 'x';
-						$placeholders['user-id'] = 0;
-						$placeholders['translate'] = ['user-email', 'user-groups', 'user-name', 'user-profile', '@user-profile', 'user-age'];
-					}
-					
-					$placeholders['count'] = 1;
-					$placeholders['count-user'] = $user ? $user->lexiconEntries : 0;
-					$placeholders['entry-link'] = $entry->getLink();
-					$placeholders['entry-subject'] = $entry->getTitle();
-					$placeholders['entry-text'] = $entry->getSimplifiedFormattedMessage();
-					
-					// log action
-					if ($bot->enableLog) {
-						// userIDs string
-						if (count($affectedUserIDs)) {
-							$userIDs = implode(', ', $affectedUserIDs);
-						}
-						else {
-							$userIDs = $defaultLanguage->get('wcf.user.guest');
-						}
-						
-						if (!$bot->testMode) {
-							UzbotLogEditor::create([
-									'bot' => $bot,
-									'count' => 1,
-									'additionalData' => $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.user.affected', [
-											'total' => 1,
-											'userIDs' => $userIDs
-									])
-							]);
-						}
-						else {
-							$result = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.test', [
-									'objects' => 1,
-									'users' => count($affectedUserIDs),
-									'userIDs' => $userIDs
-							]);
-							if (mb_strlen($result) > 64000) $result = mb_substr($result, 0, 64000) . ' ...';
-							UzbotLogEditor::create([
-									'bot' => $bot,
-									'count' => 1,
-									'testMode' => 1,
-									'additionalData' => serialize(['', '', $result])
-							]);
-						}
-					}
-					
-					// check for and prepare notification
-					$notify = $bot->checkNotify(true, true);
-					if ($notify === null) continue;
-					
-					// send to scheduler
-					$data = [
-							'bot' => $bot,
-							'placeholders' => $placeholders,
-							'affectedUserIDs' => $affectedUserIDs,
-							'countToUserID' => $countToUserID
-					];
-					
-					$job = new NotifyScheduleBackgroundJob($data);
-					BackgroundQueueHandler::getInstance()->performJob($job);
-				}
-			}
-		}
-		
-		// entry change
-		if ($action == 'update' || $action == 'delete') {
-			$entry = $eventObj->getObjects()[0]->getDecoratedObject();
-			
-			$bots = UzbotValidBotCacheBuilder::getInstance()->getData(['typeDes' => 'lexicon_change']);
-			
-			if (count($bots)) {
-				$user = WCF::getUser(); // changing user
-				
-				// get reason
-				$params = $eventObj->getParameters();
-				$reason = '';
-				if (isset($params['comment'])) $reason = $params['comment'];
-				elseif (isset($params['data']['comment'])) $reason = $params['data']['comment'];
-				
-				foreach ($bots as $bot) {
-					// check type of change
-					if ($action == 'update' && !$bot->lexiconChangeUpdate) continue;
-					if ($action == 'delete' && !$bot->lexiconChangeDelete) continue;
-					
-					$affectedUserIDs = $countToUserID = $placeholders = [];
-					$count = 1;
-					
-					$conditions = $bot->getUserConditions();
-					if (count($conditions)) {
-						$userList = new UserList();
-						$userList->getConditionBuilder()->add('user_table.userID = ?', [$entry->userID]);
-						foreach ($conditions as $condition) {
-							$condition->getObjectType()->getProcessor()->addUserCondition($condition, $userList);
-						}
-						$userList->readObjects();
-						if (!count($userList->getObjects())) continue;
-					}
-					
-					// found one
-					$affectedUserIDs[] = $entry->userID;
-					if ($entry->userID) {
-						$entryUser = new User($entry->userID);
-						if ($entryUser->userID) {
-							$countToUserID[$entry->userID] = $entryUser->lexiconEntries;
-						}
-					}
-					
-					// set placeholders
-					$placeholders['action'] = $action == 'update' ? 'wcf.acp.uzbot.lexicon.action.changed' : 'wcf.acp.uzbot.lexicon.action.deleted';
-					$placeholders['count'] = 1;
-					$placeholders['count-user'] = 1;
-					$placeholders['entry-id'] = $entry->entryID;
-					$placeholders['entry-link'] = $entry->getLink();
-					$placeholders['entry-subject'] = $entry->getTitle();
-					$placeholders['entry-text'] = $entry->getSimplifiedFormattedMessage();
-					$placeholders['entry-username'] = $entry->username;
-					$placeholders['changing-username'] = $user->username;
-					$placeholders['reason'] = $reason;
-					$placeholders['translate'] = ['action', 'changing-username'];
-					
-					// log action
-					if ($bot->enableLog) {
-						if (!$bot->testMode) {
-							UzbotLogEditor::create([
-									'bot' => $bot,
-									'count' => 1,
-									'additionalData' => $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.user.affected', [
-											'total' => 1,
-											'userIDs' => implode(', ', $affectedUserIDs)
-									])
-							]);
-						}
-						else {
-							$result = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.test', [
-									'objects' => 1,
-									'users' => count($affectedUserIDs),
-									'userIDs' => implode(', ', $affectedUserIDs)
-							]);
-								if (mb_strlen($result) > 64000) $result = mb_substr($result, 0, 64000) . ' ...';
-								UzbotLogEditor::create([
-										'bot' => $bot,
-										'count' => 1,
-										'testMode' => 1,
-										'additionalData' => serialize(['', '', $result])
-								]);
-							}
-						}
-						
-						// check for and prepare notification
-						$notify = $bot->checkNotify(true, true);
-						if ($notify === null) continue;
-						
-						// send to scheduler
-						$data = [
-								'bot' => $bot,
-								'placeholders' => $placeholders,
-								'affectedUserIDs' => $affectedUserIDs,
-								'countToUserID' => $countToUserID
-						];
-						
-						$job = new NotifyScheduleBackgroundJob($data);
-						BackgroundQueueHandler::getInstance()->performJob($job);
-					}
-			}
-		}
-	}
+class UzbotLexiconActionListener implements IParameterizedEventListener
+{
+    /**
+     * @inheritDoc
+     */
+    public function execute($eventObj, $className, $eventName, array &$parameters)
+    {
+        // check module
+        if (!MODULE_UZBOT) {
+            return;
+        }
+
+        $action = $eventObj->getActionName();
+        $defaultLanguage = LanguageFactory::getInstance()->getLanguage(LanguageFactory::getInstance()->getDefaultLanguageID());
+
+        // entry publication
+        if ($action == 'triggerPublication') {
+            // Read all active, valid bots, abort if none
+            $bots = UzbotValidBotCacheBuilder::getInstance()->getData(['typeDes' => 'lexicon_new']);
+            if (!\count($bots)) {
+                return;
+            }
+
+            // get entries
+            $entries = $eventObj->getObjects();
+            if (!\count($entries)) {
+                return;
+            }
+
+            foreach ($entries as $editor) {
+                $entry = $editor->getDecoratedObject();
+
+                foreach ($bots as $bot) {
+                    $affectedUserIDs = $countToUserID = $placeholders = [];
+                    $count = 1;
+
+                    // check for conditions, if exist, no guests
+                    $conditions = $bot->getUserConditions();
+                    if (\count($conditions)) {
+                        if (!$entry->userID) {
+                            continue;
+                        } else {
+                            $userList = new UserList();
+                            $userList->getConditionBuilder()->add('user_table.userID = ?', [$entry->userID]);
+                            foreach ($conditions as $condition) {
+                                $condition->getObjectType()->getProcessor()->addUserCondition($condition, $userList);
+                            }
+                            $userList->readObjects();
+                            if (!\count($userList->getObjects())) {
+                                continue;
+                            }
+                        }
+                    }
+
+                    // affected user
+                    $user = null;
+                    if ($entry->userID) {
+                        $user = new User($entry->userID);
+                        if (!$user->userID) {
+                            $user = null;
+                        }
+                    }
+
+                    if ($user) {
+                        $affectedUserIDs[] = $user->userID;
+                        $countToUserID[$user->userID] = 1;
+                    } else {
+                        $placeholders['user-email'] = $placeholders['user-groups'] = 'wcf.user.guest';
+                        $placeholders['user-name'] = $placeholders['user-profile'] = $placeholders['@user-profile'] = 'wcf.user.guest';
+                        $placeholders['user-age'] = 'x';
+                        $placeholders['user-id'] = 0;
+                        $placeholders['translate'] = ['user-email', 'user-groups', 'user-name', 'user-profile', '@user-profile', 'user-age'];
+                    }
+
+                    $placeholders['count'] = 1;
+                    $placeholders['count-user'] = $user ? $user->lexiconEntries : 0;
+                    $placeholders['entry-link'] = $entry->getLink();
+                    $placeholders['entry-subject'] = $entry->getTitle();
+                    $placeholders['entry-text'] = $entry->getSimplifiedFormattedMessage();
+
+                    // log action
+                    if ($bot->enableLog) {
+                        // userIDs string
+                        if (\count($affectedUserIDs)) {
+                            $userIDs = \implode(', ', $affectedUserIDs);
+                        } else {
+                            $userIDs = $defaultLanguage->get('wcf.user.guest');
+                        }
+
+                        if (!$bot->testMode) {
+                            UzbotLogEditor::create([
+                                'bot' => $bot,
+                                'count' => 1,
+                                'additionalData' => $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.user.affected', [
+                                    'total' => 1,
+                                    'userIDs' => $userIDs,
+                                ]),
+                            ]);
+                        } else {
+                            $result = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.test', [
+                                'objects' => 1,
+                                'users' => \count($affectedUserIDs),
+                                'userIDs' => $userIDs,
+                            ]);
+                            if (\mb_strlen($result) > 64000) {
+                                $result = \mb_substr($result, 0, 64000) . ' ...';
+                            }
+                            UzbotLogEditor::create([
+                                'bot' => $bot,
+                                'count' => 1,
+                                'testMode' => 1,
+                                'additionalData' => \serialize(['', '', $result]),
+                            ]);
+                        }
+                    }
+
+                    // check for and prepare notification
+                    $notify = $bot->checkNotify(true, true);
+                    if ($notify === null) {
+                        continue;
+                    }
+
+                    // send to scheduler
+                    $data = [
+                        'bot' => $bot,
+                        'placeholders' => $placeholders,
+                        'affectedUserIDs' => $affectedUserIDs,
+                        'countToUserID' => $countToUserID,
+                    ];
+
+                    $job = new NotifyScheduleBackgroundJob($data);
+                    BackgroundQueueHandler::getInstance()->performJob($job);
+                }
+            }
+        }
+
+        // entry change
+        if ($action == 'update' || $action == 'delete') {
+            $entry = $eventObj->getObjects()[0]->getDecoratedObject();
+
+            $bots = UzbotValidBotCacheBuilder::getInstance()->getData(['typeDes' => 'lexicon_change']);
+
+            if (\count($bots)) {
+                $user = WCF::getUser(); // changing user
+
+                // get reason
+                $params = $eventObj->getParameters();
+                $reason = '';
+                if (isset($params['comment'])) {
+                    $reason = $params['comment'];
+                } elseif (isset($params['data']['comment'])) {
+                    $reason = $params['data']['comment'];
+                }
+
+                foreach ($bots as $bot) {
+                    // check type of change
+                    if ($action == 'update' && !$bot->lexiconChangeUpdate) {
+                        continue;
+                    }
+                    if ($action == 'delete' && !$bot->lexiconChangeDelete) {
+                        continue;
+                    }
+
+                    $affectedUserIDs = $countToUserID = $placeholders = [];
+                    $count = 1;
+
+                    $conditions = $bot->getUserConditions();
+                    if (\count($conditions)) {
+                        $userList = new UserList();
+                        $userList->getConditionBuilder()->add('user_table.userID = ?', [$entry->userID]);
+                        foreach ($conditions as $condition) {
+                            $condition->getObjectType()->getProcessor()->addUserCondition($condition, $userList);
+                        }
+                        $userList->readObjects();
+                        if (!\count($userList->getObjects())) {
+                            continue;
+                        }
+                    }
+
+                    // found one
+                    $affectedUserIDs[] = $entry->userID;
+                    if ($entry->userID) {
+                        $entryUser = new User($entry->userID);
+                        if ($entryUser->userID) {
+                            $countToUserID[$entry->userID] = $entryUser->lexiconEntries;
+                        }
+                    }
+
+                    // set placeholders
+                    $placeholders['action'] = $action == 'update' ? 'wcf.acp.uzbot.lexicon.action.changed' : 'wcf.acp.uzbot.lexicon.action.deleted';
+                    $placeholders['count'] = 1;
+                    $placeholders['count-user'] = 1;
+                    $placeholders['entry-id'] = $entry->entryID;
+                    $placeholders['entry-link'] = $entry->getLink();
+                    $placeholders['entry-subject'] = $entry->getTitle();
+                    $placeholders['entry-text'] = $entry->getSimplifiedFormattedMessage();
+                    $placeholders['entry-username'] = $entry->username;
+                    $placeholders['changing-username'] = $user->username;
+                    $placeholders['reason'] = $reason;
+                    $placeholders['translate'] = ['action', 'changing-username'];
+
+                    // log action
+                    if ($bot->enableLog) {
+                        if (!$bot->testMode) {
+                            UzbotLogEditor::create([
+                                'bot' => $bot,
+                                'count' => 1,
+                                'additionalData' => $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.user.affected', [
+                                    'total' => 1,
+                                    'userIDs' => \implode(', ', $affectedUserIDs),
+                                ]),
+                            ]);
+                        } else {
+                            $result = $defaultLanguage->getDynamicVariable('wcf.acp.uzbot.log.test', [
+                                'objects' => 1,
+                                'users' => \count($affectedUserIDs),
+                                'userIDs' => \implode(', ', $affectedUserIDs),
+                            ]);
+                            if (\mb_strlen($result) > 64000) {
+                                $result = \mb_substr($result, 0, 64000) . ' ...';
+                            }
+                            UzbotLogEditor::create([
+                                'bot' => $bot,
+                                'count' => 1,
+                                'testMode' => 1,
+                                'additionalData' => \serialize(['', '', $result]),
+                            ]);
+                        }
+                    }
+
+                    // check for and prepare notification
+                    $notify = $bot->checkNotify(true, true);
+                    if ($notify === null) {
+                        continue;
+                    }
+
+                    // send to scheduler
+                    $data = [
+                        'bot' => $bot,
+                        'placeholders' => $placeholders,
+                        'affectedUserIDs' => $affectedUserIDs,
+                        'countToUserID' => $countToUserID,
+                    ];
+
+                    $job = new NotifyScheduleBackgroundJob($data);
+                    BackgroundQueueHandler::getInstance()->performJob($job);
+                }
+            }
+        }
+    }
 }

--- a/files/lib/system/event/listener/UzbotLexiconDeleteBotListener.class.php
+++ b/files/lib/system/event/listener/UzbotLexiconDeleteBotListener.class.php
@@ -1,30 +1,54 @@
 <?php
+
+/*
+ * Copyright by Udo Zaydowicz.
+ * Modified by SoftCreatR.dev.
+ *
+ * License: http://opensource.org/licenses/lgpl-license.php
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 namespace lexicon\system\event\listener;
+
 use wcf\system\condition\ConditionHandler;
 use wcf\system\event\listener\IParameterizedEventListener;
 use wcf\system\WCF;
 
 /**
  * Listen to Uzbot deletion for conditions
- *  
- * @author		2019-2022 Zaydowicz
- * @license		GNU Lesser General Public License <http://opensource.org/licenses/lgpl-license.php>
- * @package		com.uz.wcf.bot3.lexicon
  */
-class UzbotLexiconDeleteBotListener implements IParameterizedEventListener {
-	/**
-	 * @inheritDoc
-	 */
-	public function execute($eventObj, $className, $eventName, array &$parameters) {
-		// check module
-		if (!MODULE_UZBOT) return;
-		
-		// only delete
-		if ($eventObj->getActionName() != 'delete') return;
-		
-		$botIDs = $eventObj->getObjectIDs();
-		if (!empty($botIDs)) {
-			$oldConditions = ConditionHandler::getInstance()->deleteConditions('com.uz.wcf.bot.condition.lexicon', $botIDs);
-		}
-	}
+class UzbotLexiconDeleteBotListener implements IParameterizedEventListener
+{
+    /**
+     * @inheritDoc
+     */
+    public function execute($eventObj, $className, $eventName, array &$parameters)
+    {
+        // check module
+        if (!MODULE_UZBOT) {
+            return;
+        }
+
+        // only delete
+        if ($eventObj->getActionName() != 'delete') {
+            return;
+        }
+
+        $botIDs = $eventObj->getObjectIDs();
+        if (!empty($botIDs)) {
+            $oldConditions = ConditionHandler::getInstance()->deleteConditions('com.uz.wcf.bot.condition.lexicon', $botIDs);
+        }
+    }
 }

--- a/language/de.xml
+++ b/language/de.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <language xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/language.xsd" languagecode="de" languagename="Deutsch" countrycode="de">
-	<category name="wcf.acp.option">
-		<item name="wcf.acp.option.uzbot_data_limit_lexicon"><![CDATA[Lexikon-Einträge]]></item>
-		<item name="wcf.acp.option.uzbot_data_limit_lexicon.description"><![CDATA[Anzahl der Lexikon-Einträge, die bei jedem Bot-Durchlauf bearbeitet werden (Modifizierung).]]></item>
-	</category>
-	
-	<category name="wcf.acp.uzbot">
-		<item name="wcf.acp.uzbot.log.lexicon.entry.modified"><![CDATA[{$action} - betroffene Einträge: {$entryIDs}]]></item>
-		<item name="wcf.acp.uzbot.log.lexicon.entry.affected"><![CDATA[Anzahl der betroffene Einträge gemäß Bedingungen: {$count}]]></item>
-		<item name="wcf.acp.uzbot.type.lexicon_change"><![CDATA[Lexikon - Eintrag - Änderung]]></item>
-		<item name="wcf.acp.uzbot.type.lexicon_modification"><![CDATA[Lexikon - Eintrag - Modifizierung]]></item>
-		<item name="wcf.acp.uzbot.type.lexicon_new"><![CDATA[Lexikon - Eintrag - Neu]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.action.changed"><![CDATA[geändert]]></item>
-		<item name="wcf.acp.uzbot.lexicon.action.deleted"><![CDATA[gelöscht]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.condition.create"><![CDATA[Tage seit Erstellung]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.edit"><![CDATA[Tage seit letzter Änderung]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.state"><![CDATA[Status]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.state.description"><![CDATA[Status des Eintrags.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.username"><![CDATA[Autor]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.username.description"><![CDATA[Benutzername des Autors des Eintrags]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entryChange.action"><![CDATA[Überwachte Aktionen]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryChange.action.error.notConfigured"><![CDATA[Es muss mindestens eine Aktion ausgewählt werden.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryChange.delete"><![CDATA[Löschen überwachen]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryChange.update"><![CDATA[Ändern überwachen]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action"><![CDATA[Auszuführende Aktion(en)]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.error.notConfigured"><![CDATA[Es muss mindestens eine Aktion ausgewählt werden.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.deleteLabels"><![CDATA[Einträge-Label gelöscht]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.done"><![CDATA[Einträge geschützt]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.undone"><![CDATA[Einträge ungeschützt]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.disable"><![CDATA[Einträge deaktiviert]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.enable"><![CDATA[Einträge aktiviert]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.setLabels"><![CDATA[Einträge-Label gesetzt]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.error.executerInvalid"><![CDATA[Der ausführende Benutzer ist ungülig. Der Bot wurde deaktiviert.]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted"><![CDATA[Geschützt]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isNotCompleted"><![CDATA[Nicht geschützt]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted.error.conflict"><![CDATA[„Geschützt“ und „Nicht geschützt“ können nicht gleichzeitig ausgewählt werden.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled"><![CDATA[Deaktiviert]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEnabled"><![CDATA[Aktiviert]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled.error.conflict"><![CDATA[„Deaktiviert“ und „Aktiviert“ können nicht gleichzeitig ausgewählt werden.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels"><![CDATA[Hat Label]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasNoLabels"><![CDATA[Hat keine Label]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels.error.conflict"><![CDATA[„Hat Label“ und „Hat keine Label“ können nicht gleichzeitig ausgewählt werden.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEdited"><![CDATA[Ist editiert]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isNotEdited"><![CDATA[Ist nicht editiert]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEdited.error.conflict"><![CDATA[„Ist editiert“ und „Ist nicht editiert“ können nicht gleichzeitig ausgewählt werden.]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entry.condition"><![CDATA[Eintrag-Bedingungen]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.description"><![CDATA[Nur Einträge, die die nachfolgenden Bedingungen erfüllen, sind von der Aktion betroffen. Werden keine Bedingungen konfiguriert, wird der Bot auf alle Einträge angewendet.]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entryModification.category"><![CDATA[In Kategorie]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.complete"><![CDATA[Schützen]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.uncomplete"><![CDATA[Schutz aufheben]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.disable"><![CDATA[Deaktivieren]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.enable"><![CDATA[Aktivieren]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.setLabels"><![CDATA[Label setzen]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.executer"><![CDATA[Ausführender Benutzer]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.executer.description"><![CDATA[Dieser Benutzer wird für das Einträge-Änderungsprotokoll benötigt.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.executer.error.empty"><![CDATA[Es muss ein Benutzername angegeben werden.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.executer.error.invalid"><![CDATA[Der Benutzer existiert nicht.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.noFound"><![CDATA[Keine Einträge gefunden.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.setting"><![CDATA[Einstellungen]]></item>
-		
-		<item name="wcf.acp.uzbot.help.type.200"><![CDATA[Lexikon - Eintrag - Änderung]]></item>
-		<item name="wcf.acp.uzbot.help.type.200.description"><![CDATA[<p>Dieser Bot überwacht die Änderung oder das Löschen von Einträgen und erstellt eine Benachrichtigung, wenn jemand einen Eintrag ändert oder löscht.</p>
+    <category name="wcf.acp.option">
+        <item name="wcf.acp.option.uzbot_data_limit_lexicon"><![CDATA[Lexikon-Einträge]]></item>
+        <item name="wcf.acp.option.uzbot_data_limit_lexicon.description"><![CDATA[Anzahl der Lexikon-Einträge, die bei jedem Bot-Durchlauf bearbeitet werden (Modifizierung).]]></item>
+    </category>
+
+    <category name="wcf.acp.uzbot">
+        <item name="wcf.acp.uzbot.log.lexicon.entry.modified"><![CDATA[{$action} - betroffene Einträge: {$entryIDs}]]></item>
+        <item name="wcf.acp.uzbot.log.lexicon.entry.affected"><![CDATA[Anzahl der betroffene Einträge gemäß Bedingungen: {$count}]]></item>
+        <item name="wcf.acp.uzbot.type.lexicon_change"><![CDATA[Lexikon - Eintrag - Änderung]]></item>
+        <item name="wcf.acp.uzbot.type.lexicon_modification"><![CDATA[Lexikon - Eintrag - Modifizierung]]></item>
+        <item name="wcf.acp.uzbot.type.lexicon_new"><![CDATA[Lexikon - Eintrag - Neu]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.action.changed"><![CDATA[geändert]]></item>
+        <item name="wcf.acp.uzbot.lexicon.action.deleted"><![CDATA[gelöscht]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.condition.create"><![CDATA[Tage seit Erstellung]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.edit"><![CDATA[Tage seit letzter Änderung]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.state"><![CDATA[Status]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.state.description"><![CDATA[Status des Eintrags.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.username"><![CDATA[Autor]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.username.description"><![CDATA[Benutzername des Autors des Eintrags]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entryChange.action"><![CDATA[Überwachte Aktionen]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryChange.action.error.notConfigured"><![CDATA[Es muss mindestens eine Aktion ausgewählt werden.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryChange.delete"><![CDATA[Löschen überwachen]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryChange.update"><![CDATA[Ändern überwachen]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action"><![CDATA[Auszuführende Aktion(en)]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.error.notConfigured"><![CDATA[Es muss mindestens eine Aktion ausgewählt werden.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.deleteLabels"><![CDATA[Einträge-Label gelöscht]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.done"><![CDATA[Einträge geschützt]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.undone"><![CDATA[Einträge ungeschützt]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.disable"><![CDATA[Einträge deaktiviert]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.enable"><![CDATA[Einträge aktiviert]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.setLabels"><![CDATA[Einträge-Label gesetzt]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.error.executerInvalid"><![CDATA[Der ausführende Benutzer ist ungülig. Der Bot wurde deaktiviert.]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted"><![CDATA[Geschützt]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isNotCompleted"><![CDATA[Nicht geschützt]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted.error.conflict"><![CDATA[„Geschützt“ und „Nicht geschützt“ können nicht gleichzeitig ausgewählt werden.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled"><![CDATA[Deaktiviert]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEnabled"><![CDATA[Aktiviert]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled.error.conflict"><![CDATA[„Deaktiviert“ und „Aktiviert“ können nicht gleichzeitig ausgewählt werden.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels"><![CDATA[Hat Label]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasNoLabels"><![CDATA[Hat keine Label]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels.error.conflict"><![CDATA[„Hat Label“ und „Hat keine Label“ können nicht gleichzeitig ausgewählt werden.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEdited"><![CDATA[Ist editiert]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isNotEdited"><![CDATA[Ist nicht editiert]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEdited.error.conflict"><![CDATA[„Ist editiert“ und „Ist nicht editiert“ können nicht gleichzeitig ausgewählt werden.]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entry.condition"><![CDATA[Eintrag-Bedingungen]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.description"><![CDATA[Nur Einträge, die die nachfolgenden Bedingungen erfüllen, sind von der Aktion betroffen. Werden keine Bedingungen konfiguriert, wird der Bot auf alle Einträge angewendet.]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entryModification.category"><![CDATA[In Kategorie]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.complete"><![CDATA[Schützen]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.uncomplete"><![CDATA[Schutz aufheben]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.disable"><![CDATA[Deaktivieren]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.enable"><![CDATA[Aktivieren]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.setLabels"><![CDATA[Label setzen]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.executer"><![CDATA[Ausführender Benutzer]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.executer.description"><![CDATA[Dieser Benutzer wird für das Einträge-Änderungsprotokoll benötigt.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.executer.error.empty"><![CDATA[Es muss ein Benutzername angegeben werden.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.executer.error.invalid"><![CDATA[Der Benutzer existiert nicht.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.noFound"><![CDATA[Keine Einträge gefunden.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.setting"><![CDATA[Einstellungen]]></item>
+
+        <item name="wcf.acp.uzbot.help.type.200"><![CDATA[Lexikon - Eintrag - Änderung]]></item>
+        <item name="wcf.acp.uzbot.help.type.200.description"><![CDATA[<p>Dieser Bot überwacht die Änderung oder das Löschen von Einträgen und erstellt eine Benachrichtigung, wenn jemand einen Eintrag ändert oder löscht.</p>
 <p>Der Verfasser des Eintrags ist der betroffene Benutzer und kann direkt adressiert werden.</p>
 <br><p>Durch Konfiguration von Allgemeinen Benutzer-Bedingungen kann die Überwachung auf bestimmte Autoren begrenzt werden.</p>
 <br><p>Die folgenden Bot-spezifischen Platzhalter stehen zur Verfügung:</p>
@@ -100,9 +100,9 @@
 <tr><td><strong>[user-profile]</strong></td><td>Link zum Profil des Benutzers</td></tr>
 <tr><td><strong>[@user-profile]</strong></td><td>Link zum Profil des Benutzers mit Benachrichtungsfunktion (nur Beiträge)</td></tr>
 </table>]]></item>
-		
-		<item name="wcf.acp.uzbot.help.type.201"><![CDATA[Lexikon - Eintrag - Modifizierung]]></item>
-		<item name="wcf.acp.uzbot.help.type.201.description"><![CDATA[<p>Dieser Bot modifiziert ausgewählte Einträge und erstellt Benachrichtigungen, wenn eine Aktion auf die betroffenen Einträge angewendet wurde. Die Anzahl der Einträge je Bot-Durchlauf kann konfiguriert werden (Standard: 50).</p>
+
+        <item name="wcf.acp.uzbot.help.type.201"><![CDATA[Lexikon - Eintrag - Modifizierung]]></item>
+        <item name="wcf.acp.uzbot.help.type.201.description"><![CDATA[<p>Dieser Bot modifiziert ausgewählte Einträge und erstellt Benachrichtigungen, wenn eine Aktion auf die betroffenen Einträge angewendet wurde. Die Anzahl der Einträge je Bot-Durchlauf kann konfiguriert werden (Standard: 50).</p>
 <p>Die Verfasser der Einträge sind die betroffenen Benutzer und können direkt adressiert werden.</p>
 <br><p>Es kann mehr als eine Aktion gewählt werden. Die Aktionen werden in der Reihenfolge wie bei der Bot-Konfiguration abgearbeitet.</p>
 <br><p>Hinweis: Es wird für jeden betroffenen Benutzer eine Benachrichtigung erstellt. Dies gilt auch für Benachrichtigungen ohne individuellen Empfänger wie Artikel, Themen oder Beiträge. Abhänging von Konfiguration und Anzahl der modifizierten Einträge können sehr viele Benachrichtigungen erstellt werden.</p>
@@ -129,9 +129,9 @@
 <tr><td><strong>[user-profile]</strong></td><td>Link zum Profil des Benutzers</td></tr>
 <tr><td><strong>[@user-profile]</strong></td><td>Link zum Profil des Benutzers mit Benachrichtungsfunktion (nur Beiträge)</td></tr>
 </table>]]></item>
-		
-		<item name="wcf.acp.uzbot.help.type.202"><![CDATA[Lexikon - Eintrag - Neu]]></item>
-		<item name="wcf.acp.uzbot.help.type.202.description"><![CDATA[<p>Dieser Bot überwacht die Veröffentlichung von Einträgen und versendet eine Benachrichtigung, wenn ein Benutzer oder Gast einen neuen Eintrag verfasst hat und dieser veröffentlicht/freigeschaltet wird.</p>
+
+        <item name="wcf.acp.uzbot.help.type.202"><![CDATA[Lexikon - Eintrag - Neu]]></item>
+        <item name="wcf.acp.uzbot.help.type.202.description"><![CDATA[<p>Dieser Bot überwacht die Veröffentlichung von Einträgen und versendet eine Benachrichtigung, wenn ein Benutzer oder Gast einen neuen Eintrag verfasst hat und dieser veröffentlicht/freigeschaltet wird.</p>
 <p>Der Verfasser des Eintrags ist der betroffene Benutzer und kann direkt adressiert werden.</p>
 <br><p>Durch Konfiguration der Allgemeinen Benutzer-Bedingungen lassen sich gezielt einzelne Benutzer überwachen.</p>
 <br><p>Die folgenden Bot-spezifischen Platzhalter stehen zur Verfügung:</p>
@@ -159,5 +159,5 @@
 <tr><td><strong>[user-profile]</strong></td><td>Link zum Profil des Benutzers</td></tr>
 <tr><td><strong>[@user-profile]</strong></td><td>Link zum Profil des Benutzers mit Benachrichtungsfunktion (nur Beiträge)</td></tr>
 </table>]]></item>
-	</category>
+    </category>
 </language>

--- a/language/en.xml
+++ b/language/en.xml
@@ -1,74 +1,74 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <language xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/language.xsd" languagecode="en" languagename="English" countrycode="gb">
-	<category name="wcf.acp.option">
-		<item name="wcf.acp.option.uzbot_data_limit_lexicon"><![CDATA[Lexicon Entries]]></item>
-		<item name="wcf.acp.option.uzbot_data_limit_lexicon.description"><![CDATA[Number of lexicon entries which are proccessed during each Bot run (modification).]]></item>
-	</category>
-	
-	<category name="wcf.acp.uzbot">
-		<item name="wcf.acp.uzbot.log.lexicon.entry.modified"><![CDATA[{$action} - affected entries: {$entryIDs}]]></item>
-		<item name="wcf.acp.uzbot.log.lexicon.entry.affected"><![CDATA[Number of affected entries iaw condition: {$count}]]></item>
-		<item name="wcf.acp.uzbot.type.lexicon_change"><![CDATA[Lexicon - Entry - Change]]></item>
-		<item name="wcf.acp.uzbot.type.lexicon_modification"><![CDATA[Lexicon - Entry - Modification]]></item>
-		<item name="wcf.acp.uzbot.type.lexicon_new"><![CDATA[Lexicon - Entry - New]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.action.changed"><![CDATA[edited]]></item>
-		<item name="wcf.acp.uzbot.lexicon.action.deleted"><![CDATA[deleted]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.condition.create"><![CDATA[Days since creation]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.edit"><![CDATA[Days since last change]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.state"><![CDATA[Status]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.state.description"><![CDATA[Status of entry.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.username"><![CDATA[Author]]></item>
-		<item name="wcf.acp.uzbot.lexicon.condition.username.description"><![CDATA[Username of the author of the entry]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entryChange.action"><![CDATA[Monitored Actions]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryChange.action.error.notConfigured"><![CDATA[At least one action must be selected.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryChange.delete"><![CDATA[Monitor deletion]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryChange.update"><![CDATA[Monitor update]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action"><![CDATA[Action(s) to be executed]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.error.notConfigured"><![CDATA[At least one action must be selected.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.deleteLabels"><![CDATA[Entry labels deleted]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.done"><![CDATA[Entry locked]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.undone"><![CDATA[Entry unlocked]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.disable"><![CDATA[Entries disabled]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.enable"><![CDATA[Entries enabled]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.action.setLabels"><![CDATA[Entries labels set]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.error.executerInvalid"><![CDATA[The executing user is invalid. The Bot was disabled.]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted"><![CDATA[Locked]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isNotCompleted"><![CDATA[Not locked]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted.error.conflict"><![CDATA[You cannot simultaneously select “Locked” and “Not locked”.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled"><![CDATA[Awaiting Approval]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEnabled"><![CDATA[Approved]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled.error.conflict"><![CDATA[You cannot simultaneously select “Awaiting Approval” and “Approved”.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels"><![CDATA[Has Labels]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasNoLabels"><![CDATA[Has no Labels]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels.error.conflict"><![CDATA[You cannot simultaneously select “Has Labels” and “Has no Labels”.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEdited"><![CDATA[Is edited]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isNotEdited"><![CDATA[Is not edited]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEdited.error.conflict"><![CDATA[You cannot simultaneously select “Is edited” and “Is not edited”.]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entry.condition"><![CDATA[Entry Conditions]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entry.condition.description"><![CDATA[Only entries which fulfill the following conditions will be affected by the action(s). The Bot will be applied to all entries if no conditions are selected.]]></item>
-		
-		<item name="wcf.acp.uzbot.lexicon.entryModification.category"><![CDATA[In category]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.complete"><![CDATA[Lock]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.uncomplete"><![CDATA[Unlock]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.disable"><![CDATA[Deactivate]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.enable"><![CDATA[Activate]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.setLabels"><![CDATA[Set labels]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.executer"><![CDATA[Executing User]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.executer.description"><![CDATA[This user is needed for the entry change log.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.executer.error.empty"><![CDATA[You must enter a username.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.executer.error.invalid"><![CDATA[The user does not exist.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.noFound"><![CDATA[No entries found.]]></item>
-		<item name="wcf.acp.uzbot.lexicon.entryModification.setting"><![CDATA[Settings]]></item>
-		
-		<item name="wcf.acp.uzbot.help.type.200"><![CDATA[Lexicon - Entry - Change]]></item>
-		<item name="wcf.acp.uzbot.help.type.200.description"><![CDATA[<p>This Bot monitors the modification or deletion of entries and sends a notification when somebody has edited or deleted an entry.</p>
+    <category name="wcf.acp.option">
+        <item name="wcf.acp.option.uzbot_data_limit_lexicon"><![CDATA[Lexicon Entries]]></item>
+        <item name="wcf.acp.option.uzbot_data_limit_lexicon.description"><![CDATA[Number of lexicon entries which are proccessed during each Bot run (modification).]]></item>
+    </category>
+
+    <category name="wcf.acp.uzbot">
+        <item name="wcf.acp.uzbot.log.lexicon.entry.modified"><![CDATA[{$action} - affected entries: {$entryIDs}]]></item>
+        <item name="wcf.acp.uzbot.log.lexicon.entry.affected"><![CDATA[Number of affected entries iaw condition: {$count}]]></item>
+        <item name="wcf.acp.uzbot.type.lexicon_change"><![CDATA[Lexicon - Entry - Change]]></item>
+        <item name="wcf.acp.uzbot.type.lexicon_modification"><![CDATA[Lexicon - Entry - Modification]]></item>
+        <item name="wcf.acp.uzbot.type.lexicon_new"><![CDATA[Lexicon - Entry - New]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.action.changed"><![CDATA[edited]]></item>
+        <item name="wcf.acp.uzbot.lexicon.action.deleted"><![CDATA[deleted]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.condition.create"><![CDATA[Days since creation]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.edit"><![CDATA[Days since last change]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.state"><![CDATA[Status]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.state.description"><![CDATA[Status of entry.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.username"><![CDATA[Author]]></item>
+        <item name="wcf.acp.uzbot.lexicon.condition.username.description"><![CDATA[Username of the author of the entry]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entryChange.action"><![CDATA[Monitored Actions]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryChange.action.error.notConfigured"><![CDATA[At least one action must be selected.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryChange.delete"><![CDATA[Monitor deletion]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryChange.update"><![CDATA[Monitor update]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action"><![CDATA[Action(s) to be executed]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.error.notConfigured"><![CDATA[At least one action must be selected.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.deleteLabels"><![CDATA[Entry labels deleted]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.done"><![CDATA[Entry locked]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.undone"><![CDATA[Entry unlocked]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.disable"><![CDATA[Entries disabled]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.enable"><![CDATA[Entries enabled]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.action.setLabels"><![CDATA[Entries labels set]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.error.executerInvalid"><![CDATA[The executing user is invalid. The Bot was disabled.]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted"><![CDATA[Locked]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isNotCompleted"><![CDATA[Not locked]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isCompleted.error.conflict"><![CDATA[You cannot simultaneously select “Locked” and “Not locked”.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled"><![CDATA[Awaiting Approval]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEnabled"><![CDATA[Approved]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isDisabled.error.conflict"><![CDATA[You cannot simultaneously select “Awaiting Approval” and “Approved”.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels"><![CDATA[Has Labels]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasNoLabels"><![CDATA[Has no Labels]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.hasLabels.error.conflict"><![CDATA[You cannot simultaneously select “Has Labels” and “Has no Labels”.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEdited"><![CDATA[Is edited]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isNotEdited"><![CDATA[Is not edited]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.state.isEdited.error.conflict"><![CDATA[You cannot simultaneously select “Is edited” and “Is not edited”.]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entry.condition"><![CDATA[Entry Conditions]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entry.condition.description"><![CDATA[Only entries which fulfill the following conditions will be affected by the action(s). The Bot will be applied to all entries if no conditions are selected.]]></item>
+
+        <item name="wcf.acp.uzbot.lexicon.entryModification.category"><![CDATA[In category]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.complete"><![CDATA[Lock]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.uncomplete"><![CDATA[Unlock]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.disable"><![CDATA[Deactivate]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.enable"><![CDATA[Activate]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.setLabels"><![CDATA[Set labels]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.executer"><![CDATA[Executing User]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.executer.description"><![CDATA[This user is needed for the entry change log.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.executer.error.empty"><![CDATA[You must enter a username.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.executer.error.invalid"><![CDATA[The user does not exist.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.noFound"><![CDATA[No entries found.]]></item>
+        <item name="wcf.acp.uzbot.lexicon.entryModification.setting"><![CDATA[Settings]]></item>
+
+        <item name="wcf.acp.uzbot.help.type.200"><![CDATA[Lexicon - Entry - Change]]></item>
+        <item name="wcf.acp.uzbot.help.type.200.description"><![CDATA[<p>This Bot monitors the modification or deletion of entries and sends a notification when somebody has edited or deleted an entry.</p>
 <p>The author of the entry is affected user and can be directly addressed.</p>
 <br><p>By configuration of general user conditions the monitoring can be limited to certain authors.</p>
 <br><p>The following Bot-specific placeholders are available:</p>
@@ -100,9 +100,9 @@
 <tr><td><strong>[user-profile]</strong></td><td>Link to the user’s profile</td></tr>
 <tr><td><strong>[@user-profile]</strong></td><td>Link to the user’s profile with notification (posts only)</td></tr>
 </table>]]></item>
-		
-		<item name="wcf.acp.uzbot.help.type.201"><![CDATA[Lexicon - Entry - Modification]]></item>
-		<item name="wcf.acp.uzbot.help.type.201.description"><![CDATA[<p>This Bot modifies selected entries and sends a notification when a modification action was applied to the entries. The number of entries per cronjob run can be configured (default: 50).</p>
+
+        <item name="wcf.acp.uzbot.help.type.201"><![CDATA[Lexicon - Entry - Modification]]></item>
+        <item name="wcf.acp.uzbot.help.type.201.description"><![CDATA[<p>This Bot modifies selected entries and sends a notification when a modification action was applied to the entries. The number of entries per cronjob run can be configured (default: 50).</p>
 <p>The authors of the entries are the affected users and can be directly addressed.</p>
 <br><p>You may choose more than one action. Actions will be executed according to the sequence in the Bot configuration.</p>
 <br><p>Notice: one notification will be created for each affected user. This is valid for notifications without individual receiver, like article, threads and posts, too. Depending on configuration and number of modified entries, a lot of notifications may be created.</p>
@@ -129,9 +129,9 @@
 <tr><td><strong>[user-profile]</strong></td><td>Link to the user’s profile</td></tr>
 <tr><td><strong>[@user-profile]</strong></td><td>Link to the user’s profile with notification (posts only)</td></tr>
 </table>]]></item>
-		
-		<item name="wcf.acp.uzbot.help.type.202"><![CDATA[Lexicon - Entry - New]]></item>
-		<item name="wcf.acp.uzbot.help.type.202.description"><![CDATA[<p>This bot monitors the publication of entries and sends a notification when a user or guest has created a new entry and the entry is published / enabled.</p>
+
+        <item name="wcf.acp.uzbot.help.type.202"><![CDATA[Lexicon - Entry - New]]></item>
+        <item name="wcf.acp.uzbot.help.type.202.description"><![CDATA[<p>This bot monitors the publication of entries and sends a notification when a user or guest has created a new entry and the entry is published / enabled.</p>
 <p>The author of the entry is the affected user and can be directly addressed.</p>
 <br><p>By configuring the general user conditions, specific users can be monitored.</p>
 <br><p>The following Bot-specific placeholders are available:</p>
@@ -159,5 +159,5 @@
 <tr><td><strong>[user-profile]</strong></td><td>Link to the user’s profile</td></tr>
 <tr><td><strong>[@user-profile]</strong></td><td>Link to the user’s profile with notification (posts only)</td></tr>
 </table>]]></item>
-	</category>
+    </category>
 </language>

--- a/objectType.xml
+++ b/objectType.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/objectType.xsd">
-	<import>
-		<type>
-			<name>com.uz.wcf.bot.condition.lexiconEntries</name>
-			<definitionname>com.uz.wcf.bot.condition.user</definitionname>
-			<classname>wcf\system\condition\UserIntegerPropertyCondition</classname>
-			<conditiongroup>contents</conditiongroup>
-			<propertyname>lexiconEntries</propertyname>
-			<minvalue>0</minvalue>
-		</type>
-		
-		<!-- action conditions -->
-		<type>
-			<name>com.uz.wcf.bot.lexicon.username</name>
-			<definitionname>com.uz.wcf.bot.condition.lexicon</definitionname>
-			<classname>lexicon\system\condition\uzbot\UzbotLexiconUsernameCondition</classname>
-			<conditionobject>com.uz.wcf.bot.lexicon</conditionobject>
-			<conditiongroup>general</conditiongroup>
-		</type>
-		
-		<type>
-			<name>com.uz.wcf.bot.lexicon.createTime</name>
-			<definitionname>com.uz.wcf.bot.condition.lexicon</definitionname>
-			<classname>lexicon\system\condition\uzbot\UzbotLexiconCreateDateIntervalCondition</classname>
-			<conditionobject>com.uz.wcf.bot.lexicon</conditionobject>
-			<conditiongroup>general</conditiongroup>
-		</type>
-		
-		<type>
-			<name>com.uz.wcf.bot.lexicon.editTime</name>
-			<definitionname>com.uz.wcf.bot.condition.lexicon</definitionname>
-			<classname>lexicon\system\condition\uzbot\UzbotLexiconEditDateIntervalCondition</classname>
-			<conditionobject>com.uz.wcf.bot.lexicon</conditionobject>
-			<conditiongroup>general</conditiongroup>
-		</type>
-		
-		<type>
-			<name>com.uz.wcf.bot.lexicon.state</name>
-			<definitionname>com.uz.wcf.bot.condition.lexicon</definitionname>
-			<classname>lexicon\system\condition\uzbot\UzbotLexiconStateCondition</classname>
-			<conditionobject>com.uz.wcf.bot.lexicon</conditionobject>
-			<conditiongroup>general</conditiongroup>
-		</type>
-	</import>
+    <import>
+        <type>
+            <name>com.uz.wcf.bot.condition.lexiconEntries</name>
+            <definitionname>com.uz.wcf.bot.condition.user</definitionname>
+            <classname>wcf\system\condition\UserIntegerPropertyCondition</classname>
+            <conditiongroup>contents</conditiongroup>
+            <propertyname>lexiconEntries</propertyname>
+            <minvalue>0</minvalue>
+        </type>
+
+        <!-- action conditions -->
+        <type>
+            <name>com.uz.wcf.bot.lexicon.username</name>
+            <definitionname>com.uz.wcf.bot.condition.lexicon</definitionname>
+            <classname>lexicon\system\condition\uzbot\UzbotLexiconUsernameCondition</classname>
+            <conditionobject>com.uz.wcf.bot.lexicon</conditionobject>
+            <conditiongroup>general</conditiongroup>
+        </type>
+
+        <type>
+            <name>com.uz.wcf.bot.lexicon.createTime</name>
+            <definitionname>com.uz.wcf.bot.condition.lexicon</definitionname>
+            <classname>lexicon\system\condition\uzbot\UzbotLexiconCreateDateIntervalCondition</classname>
+            <conditionobject>com.uz.wcf.bot.lexicon</conditionobject>
+            <conditiongroup>general</conditiongroup>
+        </type>
+
+        <type>
+            <name>com.uz.wcf.bot.lexicon.editTime</name>
+            <definitionname>com.uz.wcf.bot.condition.lexicon</definitionname>
+            <classname>lexicon\system\condition\uzbot\UzbotLexiconEditDateIntervalCondition</classname>
+            <conditionobject>com.uz.wcf.bot.lexicon</conditionobject>
+            <conditiongroup>general</conditiongroup>
+        </type>
+
+        <type>
+            <name>com.uz.wcf.bot.lexicon.state</name>
+            <definitionname>com.uz.wcf.bot.condition.lexicon</definitionname>
+            <classname>lexicon\system\condition\uzbot\UzbotLexiconStateCondition</classname>
+            <conditionobject>com.uz.wcf.bot.lexicon</conditionobject>
+            <conditiongroup>general</conditiongroup>
+        </type>
+    </import>
 </data>

--- a/objectTypeDefinition.xml
+++ b/objectTypeDefinition.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/objectTypeDefinition.xsd">
-	<import>
-		<definition>
-			<name>com.uz.wcf.bot.condition.lexicon</name>
-			<interfacename>wcf\system\condition\IObjectListCondition</interfacename>
-		</definition>
-	</import>
+    <import>
+        <definition>
+            <name>com.uz.wcf.bot.condition.lexicon</name>
+            <interfacename>wcf\system\condition\IObjectListCondition</interfacename>
+        </definition>
+    </import>
 </data>

--- a/option.xml
+++ b/option.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/option.xsd">
-	<import>
-		<options>
-			<option name="uzbot_data_limit_lexicon">
-				<categoryname>uzbot.general.data</categoryname>
-				<optiontype>integer</optiontype>
-				<defaultvalue>50</defaultvalue>
-				<minvalue>50</minvalue>
-				<maxvalue>5000</maxvalue>
-			</option>
-		</options>
-	</import>
+    <import>
+        <options>
+            <option name="uzbot_data_limit_lexicon">
+                <categoryname>uzbot.general.data</categoryname>
+                <optiontype>integer</optiontype>
+                <defaultvalue>50</defaultvalue>
+                <minvalue>50</minvalue>
+                <maxvalue>5000</maxvalue>
+            </option>
+        </options>
+    </import>
 </data>

--- a/package.xml
+++ b/package.xml
@@ -1,51 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package name="com.uz.wcf.bot3.lexicon" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/package.xsd">
-	<packageinformation>
-		<packagename>Community Bot 3 - Lexicon Extension</packagename>
-		<packagedescription>Adds Lexicon functions to Community Bot 3</packagedescription>
-		<packagename language="de">Community Bot 3 - Lexikon-Erweiterung</packagename>
-		<packagedescription language="de">Erweitert Community Bot 3 um Lexikon-Funktionen</packagedescription>
-		<version>5.5.1</version>
-		<date>2022-07-10</date>
-	</packageinformation>
-	
-	<authorinformation>
-		<author>Zaydowicz</author>
-	</authorinformation>
-	
-	<requiredpackages>
-		<requiredpackage minversion="5.4.0">com.uz.wcf.bot3</requiredpackage>
-		<requiredpackage minversion="7.0.0">com.viecode.lexicon</requiredpackage>
-		<requiredpackage minversion="5.4.0">com.woltlab.wcf</requiredpackage>
-	</requiredpackages>
-	
-	<excludedpackages>
-		<excludedpackage version="5.6.0 Alpha 1">com.woltlab.wcf</excludedpackage>
-	</excludedpackages>
-	
-	<instructions type="install">
-		<instruction type="eventListener">eventListener.xml</instruction>
-		<instruction type="file" application="lexicon">files.tar</instruction>
-		<instruction type="language">language/*.xml</instruction>
-		<instruction type="sql" run="standalone">update_uzbot.sql</instruction>
-		<instruction type="option">option.xml</instruction>
-		<instruction type="cronjob">cronjob.xml</instruction>
-		<instruction type="objectTypeDefinition">objectTypeDefinition.xml</instruction>
-		<instruction type="objectType">objectType.xml</instruction>
-		<instruction type="templateListener">templateListener.xml</instruction>
-		<instruction type="acpTemplate" application="lexicon">acptemplates.tar</instruction>
-		<instruction type="uzbotType">uzbotType.xml</instruction>
-	</instructions>
-	
-	<instructions type="update" fromversion="5.3.*">
-		<instruction type="file" application="lexicon">files.tar</instruction>
-	</instructions>
-	
-	<instructions type="update" fromversion="5.4.*">
-		<instruction type="file" application="lexicon">files.tar</instruction>
-	</instructions>
-	
-	<instructions type="update" fromversion="5.5.0">
-		<instruction type="file" application="lexicon">files.tar</instruction>
-	</instructions>
+<package name="de.softcreatr.wcf.bot3.lexicon" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com https://www.woltlab.com/XSD/2019/package.xsd">
+    <packageinformation>
+        <packagename>Community Bot 3 - Lexicon Extension</packagename>
+        <packagedescription>Adds Lexicon functions to Community Bot 3</packagedescription>
+        <packagename language="de">Community Bot 3 - Lexikon-Erweiterung</packagename>
+        <packagedescription language="de">Erweitert Community Bot 3 um Lexikon-Funktionen</packagedescription>
+        <version>5.5.2</version>
+        <date>2022-09-18</date>
+    </packageinformation>
+
+    <authorinformation>
+        <author><![CDATA[SoftCreatR.dev]]></author>
+        <authorurl><![CDATA[https://softcreatr.dev]]></authorurl>
+    </authorinformation>
+
+    <requiredpackages>
+        <requiredpackage minversion="5.4.0">de.softcreatr.wcf.bot3</requiredpackage>
+        <requiredpackage minversion="7.0.0">com.viecode.lexicon</requiredpackage>
+        <requiredpackage minversion="5.4.0">com.woltlab.wcf</requiredpackage>
+    </requiredpackages>
+
+    <excludedpackages>
+        <excludedpackage version="5.6.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+        <excludedpackage version="*">com.uz.wcf.bot3.lexicon</excludedpackage>
+    </excludedpackages>
+
+    <instructions type="install">
+        <instruction type="eventListener" />
+        <instruction type="file" application="lexicon" />
+        <instruction type="language" />
+        <instruction type="sql" run="standalone">update_uzbot.sql</instruction>
+        <instruction type="option" />
+        <instruction type="cronjob" />
+        <instruction type="objectTypeDefinition" />
+        <instruction type="objectType" />
+        <instruction type="templateListener" />
+        <instruction type="acpTemplate" application="lexicon" />
+        <instruction type="uzbotType" />
+    </instructions>
+
+    <instructions type="update" fromversion="5.3.*">
+        <instruction type="file" application="lexicon" />
+    </instructions>
+
+    <instructions type="update" fromversion="5.4.*">
+        <instruction type="file" application="lexicon" />
+    </instructions>
+
+    <instructions type="update" fromversion="5.5.0">
+        <instruction type="file" application="lexicon" />
+    </instructions>
+
+    <instructions type="update" fromversion="5.5.1">
+        <instruction type="eventListener" />
+        <instruction type="file" application="lexicon" />
+        <instruction type="language" />
+        <instruction type="option" />
+        <instruction type="cronjob" />
+        <instruction type="objectTypeDefinition" />
+        <instruction type="objectType" />
+        <instruction type="templateListener" />
+        <instruction type="acpTemplate" application="lexicon" />
+        <instruction type="uzbotType" />
+    </instructions>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,7 @@
         <packagedescription language="de">Erweitert Community Bot 3 um Lexikon-Funktionen</packagedescription>
         <version>5.5.2</version>
         <date>2022-09-18</date>
+        <license><![CDATA[LGPL <https://opensource.org/licenses/lgpl-license.php>]]></license>
     </packageinformation>
 
     <authorinformation>

--- a/templateListener.xml
+++ b/templateListener.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/templateListener.xsd">
-	<import>
-		<templatelistener name="uzbotTypeLexicon">
-			<environment>admin</environment>
-			<templatename>uzbotAdd</templatename>
-			<eventname>UzbotType</eventname>
-			<templatecode><![CDATA[{include file='__uzbotAddTypeLexicon' application='lexicon'}]]></templatecode>
-		</templatelistener>
-		<templatelistener name="uzbotTypeLexiconJS">
-			<environment>admin</environment>
-			<templatename>uzbotAdd</templatename>
-			<eventname>UzbotTypeJS</eventname>
-			<templatecode><![CDATA[{include file='__uzbotAddTypeLexiconJS' application='lexicon'}]]></templatecode>
-		</templatelistener>
-	</import>
+    <import>
+        <templatelistener name="uzbotTypeLexicon">
+            <environment>admin</environment>
+            <templatename>uzbotAdd</templatename>
+            <eventname>UzbotType</eventname>
+            <templatecode><![CDATA[{include file='__uzbotAddTypeLexicon' application='lexicon'}]]></templatecode>
+        </templatelistener>
+        <templatelistener name="uzbotTypeLexiconJS">
+            <environment>admin</environment>
+            <templatename>uzbotAdd</templatename>
+            <eventname>UzbotTypeJS</eventname>
+            <templatecode><![CDATA[{include file='__uzbotAddTypeLexiconJS' application='lexicon'}]]></templatecode>
+        </templatelistener>
+    </import>
 </data>

--- a/update_uzbot.sql
+++ b/update_uzbot.sql
@@ -1,9 +1,9 @@
-ALTER TABLE wcf1_uzbot ADD lexiconModificationData		TEXT;
+ALTER TABLE wcf1_uzbot ADD lexiconModificationData        TEXT;
 
-ALTER TABLE wcf1_uzbot ADD lexiconCountAction			VARCHAR(15);
-ALTER TABLE wcf1_uzbot ADD topLexiconCount				INT(10) DEFAULT 1;
-ALTER TABLE wcf1_uzbot ADD topLexiconInterval			TINYINT(1) DEFAULT 1;
-ALTER TABLE wcf1_uzbot ADD topLexiconNext				INT(10) DEFAULT 0;
+ALTER TABLE wcf1_uzbot ADD lexiconCountAction            VARCHAR(15);
+ALTER TABLE wcf1_uzbot ADD topLexiconCount                INT(10) DEFAULT 1;
+ALTER TABLE wcf1_uzbot ADD topLexiconInterval            TINYINT(1) DEFAULT 1;
+ALTER TABLE wcf1_uzbot ADD topLexiconNext                INT(10) DEFAULT 0;
 
-ALTER TABLE wcf1_uzbot ADD lexiconChangeUpdate			TINYINT(1) DEFAULT 1;
-ALTER TABLE wcf1_uzbot ADD lexiconChangeDelete			TINYINT(1) DEFAULT 1;
+ALTER TABLE wcf1_uzbot ADD lexiconChangeUpdate            TINYINT(1) DEFAULT 1;
+ALTER TABLE wcf1_uzbot ADD lexiconChangeDelete            TINYINT(1) DEFAULT 1;

--- a/uzbotType.xml
+++ b/uzbotType.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/uzbotType.xsd">
-	<import>
-		<uzbotType name="lexicon_change">
-			<typeID>200</typeID>
-			<application>Lexicon</application>
-			<canCondense>0</canCondense>
-			<hasAffected>1</hasAffected>
-			<allowGuest>1</allowGuest>
-			<canChangeAffected>0</canChangeAffected>
-			<needCount>0</needCount>
-			<needCountAction></needCountAction>
-			<needCountNo></needCountNo>
-			<neededModule></neededModule>
-			<needNotify>1</needNotify>
-			<sortOrder>200</sortOrder>
-		</uzbotType>
-		
-		<uzbotType name="lexicon_modification">
-			<typeID>201</typeID>
-			<application>Lexicon</application>
-			<canCondense>0</canCondense>
-			<hasAffected>1</hasAffected>
-			<allowGuest>1</allowGuest>
-			<canChangeAffected>0</canChangeAffected>
-			<needCount>0</needCount>
-			<needCountAction></needCountAction>
-			<needCountNo></needCountNo>
-			<neededModule></neededModule>
-			<needNotify>0</needNotify>
-			<sortOrder>201</sortOrder>
-		</uzbotType>
-		
-		<uzbotType name="lexicon_new">
-			<typeID>202</typeID>
-			<application>Lexicon</application>
-			<canCondense>0</canCondense>
-			<hasAffected>1</hasAffected>
-			<allowGuest>1</allowGuest>
-			<canChangeAffected>0</canChangeAffected>
-			<needCount>0</needCount>
-			<needCountAction></needCountAction>
-			<needCountNo></needCountNo>
-			<neededModule></neededModule>
-			<needNotify>1</needNotify>
-			<sortOrder>202</sortOrder>
-		</uzbotType>
-	</import>
+    <import>
+        <uzbotType name="lexicon_change">
+            <typeID>200</typeID>
+            <application>Lexicon</application>
+            <canCondense>0</canCondense>
+            <hasAffected>1</hasAffected>
+            <allowGuest>1</allowGuest>
+            <canChangeAffected>0</canChangeAffected>
+            <needCount>0</needCount>
+            <needCountAction></needCountAction>
+            <needCountNo></needCountNo>
+            <neededModule></neededModule>
+            <needNotify>1</needNotify>
+            <sortOrder>200</sortOrder>
+        </uzbotType>
+
+        <uzbotType name="lexicon_modification">
+            <typeID>201</typeID>
+            <application>Lexicon</application>
+            <canCondense>0</canCondense>
+            <hasAffected>1</hasAffected>
+            <allowGuest>1</allowGuest>
+            <canChangeAffected>0</canChangeAffected>
+            <needCount>0</needCount>
+            <needCountAction></needCountAction>
+            <needCountNo></needCountNo>
+            <neededModule></neededModule>
+            <needNotify>0</needNotify>
+            <sortOrder>201</sortOrder>
+        </uzbotType>
+
+        <uzbotType name="lexicon_new">
+            <typeID>202</typeID>
+            <application>Lexicon</application>
+            <canCondense>0</canCondense>
+            <hasAffected>1</hasAffected>
+            <allowGuest>1</allowGuest>
+            <canChangeAffected>0</canChangeAffected>
+            <needCount>0</needCount>
+            <needCountAction></needCountAction>
+            <needCountNo></needCountNo>
+            <neededModule></neededModule>
+            <needNotify>1</needNotify>
+            <sortOrder>202</sortOrder>
+        </uzbotType>
+    </import>
 </data>


### PR DESCRIPTION
Changes:

- Renamed package from `com.uz.wcf.bot3.lexicon` to `de.softcreatr.wcf.bot3.lexicon`
- Added release workflow
- Added phpcs-fixer configuration
- Replaced tabs with spaces
- Added license information to every PHP file
- Added LICENSE file
- Several code style fixes (PSR-12)